### PR TITLE
This fixes #50. -  only generates the code from triggers

### DIFF
--- a/plugins/javascript.js
+++ b/plugins/javascript.js
@@ -21,12 +21,9 @@ yepnope({
 var parentTrigger = false;
 jQuery.fn.extend({
   extract_script: function(){
-      console.log(this);
-      if(this.is(".trigger")){
-          parentTrigger = true;
-      }
-      if(!parentTrigger)
-          return;
+	if(this.parent().is(".scripts_workspace"))
+	    if(!this.is(".trigger"))
+		return '\n\n /*not attached to a trigger*/ \n';
           
       if (this.length === 0) return '';
       if (this.is(':input')){


### PR DESCRIPTION
The extract_scripts only generates the code from triggers.
Free floating blocks are not included in the output script.

Need a visual way to show this.
@gissues:{"order":96.7914438502674,"status":"backlog"}
