### PR TITLE
Fix scrolling Issue #64

### DIFF
--- a/plugins/arduino.js
+++ b/plugins/arduino.js
@@ -40,7 +40,7 @@ window.update_scripts_view = function(){
 }
 
 function run_scripts(event){
-    $(document.body).scrollLeft(10000);
+    $('.stage')[0].scrollIntoView();
     var blocks = $('.workspace:visible .scripts_workspace > .trigger');
     $('.stage').replaceWith('<div class="stage"><script>' + blocks.wrap_script() + '</script></div>');
 }

--- a/plugins/javascript.js
+++ b/plugins/javascript.js
@@ -163,7 +163,7 @@ window.update_scripts_view = function(){
 }
 
 function run_scripts(event){
-    $(document.body).scrollLeft(10000);
+    $('.stage')[0].scrollIntoView();
     var blocks = $('.workspace:visible .scripts_workspace > .trigger');
     $('.stage').replaceWith('<div class="stage"><script>' + blocks.wrap_script() + '</script></div>');
 }

--- a/plugins/javascript_processing.js
+++ b/plugins/javascript_processing.js
@@ -163,7 +163,7 @@ window.update_scripts_view = function(){
 }
 
 function run_scripts(event){
-    $(document.body).scrollLeft(10000);
+    $('.stage')[0].scrollIntoView();
     var blocks = $('.workspace:visible .scripts_workspace > .trigger');
     $('.stage').replaceWith('<div class="stage"><script>' + blocks.wrap_script() + '</script></div>');
 }

--- a/scripts/workspace.js
+++ b/scripts/workspace.js
@@ -59,8 +59,8 @@ function clear_scripts(event, force){
 }
 $('.clear_scripts').click(clear_scripts);
 
-$('.goto_script').click(function(){$(document.body).scrollLeft(0);});
-$('.goto_stage').click(function(){$(document.body).scrollLeft(100000);});
+$('.goto_script').click(function(){$('.block_menu')[0].scrollIntoView();});
+$('.goto_stage').click(function(){$('.stage')[0].scrollIntoView();});
 
 // Load and Save Section
 
@@ -75,7 +75,7 @@ function scripts_as_object(){
 
 function save_current_scripts(){
     show_workspace();
-    $(document.body).scrollLeft(0);
+    $('.block_menu')[0].scrollIntoView();
     localStorage['__current_scripts'] = JSON.stringify(scripts_as_object());
 }
 $(window).unload(save_current_scripts);


### PR DESCRIPTION
Just changing $(document) to $(document.body) before calling .scrollLeft worked in Firefox, but not in Chrome. I changed it to $('.block_menu')[0].scrollIntoView() to scroll left and $('.stage')[0].scrollIntoView() to scroll right.

I noticed that scrolling between these with the mouse (or two-finger drag) also does not work, but I'm not sure if that's a bug or a feature. The whole scrolling between views was an artifact of a rush job to get some kind of IDE thrown together before JSConf and needs a rethink.

Note the [0] in the above fix: scrollIntoView is well supported across modern browsers, but it is a DOM method, not a jQuery method, so we have to get the DOM object out of jQuery before calling it.
