### PR TITLE
This fixes #90. Buttons are always visible.

### DIFF
--- a/stylesheets/workspace.css
+++ b/stylesheets/workspace.css
@@ -52,7 +52,7 @@ body {
     position: absolute;
     left: 15%;
     bottom: 0px;
-    width: 35%;
+    width: 34.8%;
     height: 95%;
     background-color: #FFF;
     border: 1px solid #CCC;
@@ -79,17 +79,18 @@ body {
 .tab_bar{
     position: absolute;
     left: 15%;
-    bottom: 95%;
-    width: 35%;
+    top: 6px;
+    width: 34.8%;
+    z-index: 15;
 }
 
 .tab_bar2{
     position: absolute;
-    right: 0%;
-    bottom: 95%;
+    right: -0.1%;
+    top: 30px;
     width: 50%;
+    z-index: 15;
 }
-
 .chrome_tab{
     float: left;
     margin-right: 5px;
@@ -120,8 +121,8 @@ body {
     position: absolute;
     height: 95%;
     right: 0px;
-    width: 50%;
-    bottom: 0px;
+    width: 49.8%;
+    bottom: -20px;
     background-color: #FFF;
     border: 1px solid #CCC;
 }


### PR DESCRIPTION
Dethe, is there a reason the layout only used `bottom`?

I changed the `.tab_bar`'s to use `top` and have a higher z-index.
Its not the nicest looking on smaller screens, but it keeps they system functional.

I'm still looking for a more eloquent solution ... but I didn't wanna delay waterbear alpha.
