### PR TITLE
115 rename blocks

### DIFF
--- a/scripts/blocks.js
+++ b/scripts/blocks.js
@@ -324,8 +324,26 @@ Block.prototype.init = function(spec){
         spec.labels = [spec.label];
         delete spec.label;
     }
-    $.extend(this, spec);
+    $.extend(true, this, spec);
     this.spec = spec; // save unmodified description
+    if (this.customReturns){
+        if (this.spec.returns.label){
+            this.spec.returns.label = this.customReturns;
+        }else{
+            this.spec.returns.labels[0] = this.customReturns;
+        }
+    }
+    if (this.customLocals){
+        this.customLocals.forEach(function(name, idx){
+            var _local = this.spec.locals[idx];
+            if (_local.label){
+                _local.label = name;
+            }else{
+                _local.labels[0] = name;
+            }
+        });
+        this.spec.locals = this.customLocals;
+    }
     if (this.id){
         Block.registerId(this.id);
     }else{
@@ -635,10 +653,27 @@ Block.prototype.changeLabel = function(labelText){
     this._view.find('> .block > .blockhead > .label').text(labelText);
     this.spec.labels[0] = labelText;
     if (this.returnOrigin){
-        this.returnOrigin.returns.spec.labels[0] = labelText;
+        // console.log('setting returnOrigin returns label: %o', this.returnOrigin);
+        if (this.returnOrigin.spec.returns.label){
+            this.returnOrigin.spec.returns.label = labelText;
+        }else{
+            this.returnOrigin.spec.returns.labels[0] = labelText;
+        }
+        this.returnOrigin.customReturns = labelText;
     }
     if (this.localOrigin){
-        this.localOrigin.locals.spec.labels[this.localIndex] = labelText;
+        var locals = this.localOrigin.spec.locals;
+        if (locals[this.localIndex].label){
+            locals[this.localIndex].label = labelText;
+        }else{
+            locals[this.localIndex].labels[0] = labelText;
+        }
+        if (!this.localOrigin.customLocals){
+            this.localOrigin.customLocals = locals.map(function(loc){
+                return loc.label || loc.labels[0];
+            });
+        }
+        this.localOrigin.customLocals[this.localIndex] = labelText;
     }
 };
 

--- a/scripts/serialization-1.0.js
+++ b/scripts/serialization-1.0.js
@@ -59,6 +59,12 @@ Block.prototype.toJSON = function(){
         id: this.id // yes, this will become problematic later
     };
     // console.info('serializing %s', this.signature);
+    if (this.customReturns){
+        serialized.customReturns = this.customReturns;
+    }
+    if (this.customLocals){
+        serialized.customLocals = this.customLocals;
+    }
     if (exists(this.values)){
         // console.info('with %s values', this.values.length);
         serialized.values = this.values.map(function(value){

--- a/stylesheets/workspace.css
+++ b/stylesheets/workspace.css
@@ -61,11 +61,16 @@ body.blocks .workspace{
 
 .scripts_workspace, .scripts_text_view {
     width: 100%;
-    height: 100%;
+    height: 80%;
     display: none;
     padding: 15px;
 	padding-top: 0;
     overflow: scroll;
+}
+
+.scripts_workspace{
+    padding-top: 30px;
+    padding-bottom: 100px;
 }
 
 .workspace.blockview .scripts_workspace{


### PR DESCRIPTION
This allows you to double-click on the blocks which represent local or global variables to rename them (and all instances of them). Not the most intuitive or discoverable UI, but works for now until someone has a better idea.
