### PR TITLE
Fixes #229 by eliminating returns, replacing with locals

### DIFF
--- a/plugins/arduino.js
+++ b/plugins/arduino.js
@@ -160,12 +160,14 @@ $('.clearScripts').click(clearScriptsDefault);
             labels: ['Create digital_output## on Pin [choice:digitalpins]'],
             script: 'digital_output## = "{{1}}"; pinMode(digital_output##, OUTPUT);',
             help: 'Create a named pin set to output',
-            returns: {
-                blocktype: 'expression',
-                label: 'digital_output##',
-                script: 'digital_output##',
-                type: 'string'
-            }
+            locals: [
+                {
+                    blocktype: 'expression',
+                    label: 'digital_output##',
+                    script: 'digital_output##',
+                    type: 'string'
+                }
+            ]
         },
         /*
         {
@@ -187,12 +189,14 @@ $('.clearScripts').click(clearScriptsDefault);
             labels: ['Create digital_input## on Pin [choice:digitalpins]'],
             script: 'digital_input## = "{{1}}"; pinMode(digital_input##, INPUT);',
             help: 'Create a named pin set to input',
-            returns: {
-                blocktype: 'expression',
-                labels: ['digital_input##'],
-                script: 'digital_input##',
-                type: 'string'
-            }
+            locals: [
+                {
+                    blocktype: 'expression',
+                    labels: ['digital_input##'],
+                    script: 'digital_input##',
+                    type: 'string'
+                }
+            ]
         },
 
         {
@@ -210,12 +214,14 @@ $('.clearScripts').click(clearScriptsDefault);
             labels: ['Create analog_input## on Pin [choice:analoginpins]'],
             script: 'analog_input## = "{{1}}"; pinMode(analog_input##, INPUT);',
             help: 'Create a named pin set to input',
-            returns: {
-                blocktype: 'expression',
-                labels: 'analog_input##'],
-                script: 'analog_input##',
-                type: 'string'
-            }
+            locals: [
+                {
+                    blocktype: 'expression',
+                    labels: 'analog_input##'],
+                    script: 'analog_input##',
+                    type: 'string'
+                }
+            ]
         },
 
         {
@@ -231,12 +237,14 @@ $('.clearScripts').click(clearScriptsDefault);
             labels: ['Create analog_output## on Pin [choice:pwmpins]'],
             script: 'analog_output## = "{{1}}"; pinMode(analog_output##, OUTPUT);',
             help: 'Create a named pin set to output',
-            returns: {
-                blocktype: 'expression',
-                labels: ['analog_output##'],
-                script: 'analog_output##',
-                type: 'string'
-            }
+            locals: [
+                {
+                    blocktype: 'expression',
+                    labels: ['analog_output##'],
+                    script: 'analog_output##',
+                    type: 'string'
+                }
+            ]
         },
 
         {

--- a/plugins/canvas.js
+++ b/plugins/canvas.js
@@ -292,36 +292,42 @@ choiceLists.rettypes = choiceLists.rettypes.concat(['color', 'image', 'shape', '
             blocktype: 'step',
             labels: ['create ImageData## with size [size]'],
             script: 'local.imageData## = local.ctx.createImageData({{1}}.w,{{1}}.h);',
-            returns: {
-                blocktype: 'expression',
-                labels: ['imageData##'],
-                script: 'local.imageData##',
-                type: 'imagedata'
-            },
+            locals: [
+                {
+                    blocktype: 'expression',
+                    labels: ['imageData##'],
+                    script: 'local.imageData##',
+                    type: 'imagedata'
+                }
+            ],
             help: 'initialize a new imageData with the specified dimensions'
         },
         {
             blocktype: 'step',
             labels: ['createImageData## from imageData [imageData]'],
             script: 'local.imageData## = local.ctx.createImageData({{1}});',
-            returns: {
-                blocktype: 'expression',
-                labels: ['imageData##'],
-                script: 'local.imageData##',
-                type: 'imagedata'
-            },
+            locals: [
+                {
+                    blocktype: 'expression',
+                    labels: ['imageData##'],
+                    script: 'local.imageData##',
+                    type: 'imagedata'
+                }
+            ],
             help: 'initialized a new imageData the same size as an existing imageData'
         },
         {
             blocktype: 'step',
             labels: ['get imageData## for rect [rect]'],
             script: 'local.imageData## = local.ctx.getImageData({{1}}.x,{{1}}.y,{{1}}.w,{{1}}.h);',
-            returns: {
-                blocktype: 'expression',
-                labels: ['imageData##'],
-                script: 'local.imageData##',
-                type: 'imagedata'
-            },
+            locals: [
+                {
+                    blocktype: 'expression',
+                    labels: ['imageData##'],
+                    script: 'local.imageData##',
+                    type: 'imagedata'
+                }
+            ],
             help: 'returns the image data from the specified rectangle'
         },
         {
@@ -517,24 +523,28 @@ choiceLists.rettypes = choiceLists.rettypes.concat(['color', 'image', 'shape', '
             labels: ['create radial gradient from point1 [point] radius1 [number:0] to point2 [point] radius2 [number:0]'],
             script: 'local.gradient## = local.ctx.createRadialGradient({{1}}.x,{{1}}.y,{{2}},{{3}}.x,{{3}}.y,{{4}});',
             help: 'create a radial gradient in the cone described by two circles',
-            returns: {
-                blocktype: 'expression',
-                labels: ['radial gradient##'],
-                script: 'local.gradient##',
-                type: 'gradient'
-            }
+            locals: [
+                {
+                    blocktype: 'expression',
+                    labels: ['radial gradient##'],
+                    script: 'local.gradient##',
+                    type: 'gradient'
+                }
+            ]
         },
         {
             blocktype: 'step',
             labels: ['create linear gradient from point1 [point] to point2 [point]'],
             script: 'local.gradient## = local.ctx.createLinearGradient({{1}}.x,{{1}}.y,{{2}}.x,{{2}}.y);',
             help: 'create a linear gradient between two points',
-            returns: {
-                blocktype: 'expression',
-                labels: ['linear gradient##'],
-                script: 'local.linear.gradient##',
-                type: 'gradient'
-            }
+            locals: [
+                {
+                    blocktype: 'expression',
+                    labels: ['linear gradient##'],
+                    script: 'local.linear.gradient##',
+                    type: 'gradient'
+                }
+            ]
         },
         {
             blocktype: 'step',
@@ -547,33 +557,39 @@ choiceLists.rettypes = choiceLists.rettypes.concat(['color', 'image', 'shape', '
             labels: ['create pattern## from image [image] repeats [choice:repetition]'],
             script: 'local.pattern## = local.ctx.createPattern({{1}}, {{2}});',
             help: 'create a pattern with the given html image',
-            returns: {
-                blocktype: 'expression',
-                labels: ['pattern##'],
-                script: 'local.pattern##',
-                type: 'pattern'
-            }
+            locals: [
+                {
+                    blocktype: 'expression',
+                    labels: ['pattern##'],
+                    script: 'local.pattern##',
+                    type: 'pattern'
+                }
+            ]
         },
 //         {
 //             labels: ['create pattern## from canvas [canvas] repeats [choice:repetition]'],
 //             script: 'local.pattern## = local.ctx.createPattern({{1}}, {{2}});',
 //             help: 'create a pattern with the given html canvas',
-//             returns: {
-//                 blocktype: 'expression',
-//                 labels: ['pattern##'],
-//                 script: 'local.pattern##',
-//                 type: 'pattern'
-//             }
+//             locals: [
+//                 {
+//                     blocktype: 'expression',
+//                     labels: ['pattern##'],
+//                     script: 'local.pattern##',
+//                     type: 'pattern'
+//                 }
+//              ]
 //         },
 //         {
 //             labels: ['create pattern## from video [video] repeats [choice:repetition]'],
 //             script: 'local.pattern## = local.ctx.createPattern({{1}}, {{2}});',
 //             help: 'create a pattern with the given html video',
-//             returns: {
-//                 blocktype: 'expression',
-//                 labels: ['pattern##'],
-//                 script: 'local.pattern##',
-//                 type: 'pattern'
+//             locals: [
+//                 {
+//                     blocktype: 'expression',
+//                     labels: ['pattern##'],
+//                     script: 'local.pattern##',
+//                     type: 'pattern'
+//                 }
 //             }
 //         },
 	]);

--- a/plugins/gamequery.js
+++ b/plugins/gamequery.js
@@ -46,12 +46,14 @@ wb.menu('Sprites', [
         labels: ['new image##  [image]'],
         script: 'var image## = new $.gameQuery.Animation({imageURL: {{1}}});',
         //script: 'local.sprite## = Gamequery.e().addComponent("2D, DOM");',
-        returns: {
-            blocktype: 'expression',
-            labels: ['image##'],
-            script: 'image##',
-            type: 'image'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['image##'],
+                script: 'image##',
+                type: 'image'
+            }
+        ],
         help: 'create a new image'
     },
 
@@ -60,12 +62,14 @@ wb.menu('Sprites', [
       labels: ['new animation##  [image] frames [number:1] width of cell [number:32] fps [number:30] '],
       script: 'var animation## = new $.gameQuery.Animation({imageURL: {{1}}, numberOfFrame: {{2}}, delta:{{3}}, rate: (1000 / {{4}}), type: $.gameQuery.ANIMATION_HORIZONTAL });',
         //script: 'local.sprite## = Gamequery.e().addComponent("2D, DOM");',
-        returns: {
-            blocktype: 'expression',
-            labels: ['animation##'],
-            script: 'animation##',
-            type: 'image'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['animation##'],
+                script: 'animation##',
+                type: 'image'
+            }
+        ],
         help: 'create a new animation'
     },
 
@@ -75,12 +79,14 @@ wb.menu('Sprites', [
       labels: ['new animation##  of XEON running '],
       script: 'var animation## = new $.gameQuery.Animation({imageURL: "./images/xeon-walking.png", numberOfFrame: 4, delta:68, rate: (1000 / 30), type: $.gameQuery.ANIMATION_HORIZONTAL });',
         //script: 'local.sprite## = Gamequery.e().addComponent("2D, DOM");',
-        returns: {
-            blocktype: 'expression',
-            labels: ['animation##'],
-            script: 'animation##',
-            type: 'image'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['animation##'],
+                script: 'animation##',
+                type: 'image'
+            }
+        ],
         help: 'create a new of xeon running'
     },
 
@@ -88,12 +94,14 @@ wb.menu('Sprites', [
       blocktype: 'step',
       labels: ['new sprite## based on [image] height [number:32] width [number:32] x [number:0] y [number:0]'],
         script: '$.playground.addSprite("sprite##",{animation: {{1}}, height:{{2}}, width: {{3}}, posx: {{4}},posy:{{5}}});',
-        returns: {
-            blocktype: 'expression',
-            labels: ['sprite##'],
-            script: 'sprite##',
-            type: 'sprite'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['sprite##'],
+                script: 'sprite##',
+                type: 'sprite'
+            }
+        ],
         help: 'create a new sprite'
     },
 ]);

--- a/plugins/javascript.js
+++ b/plugins/javascript.js
@@ -173,12 +173,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable string## [string]'],
         script: 'local.string## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['string##'],
-            script: 'local.string##',
-            type: 'string'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['string##'],
+                script: 'local.string##',
+                type: 'string'
+            }
+        ],
         help: 'create a reference to re-use the string'
     },
     {
@@ -191,12 +193,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable number## [number]'],
         script: 'local.number## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['number##'],
-            script: 'local.number##',
-            type: 'number'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['number##'],
+                script: 'local.number##',
+                type: 'number'
+            }
+        ],
         help: 'create a reference to re-use the number'
     },
     {
@@ -209,12 +213,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable boolean## [boolean]'],
         script: 'local.boolean## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['boolean##'],
-            script: 'local.boolean##',
-            type: 'boolean'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['boolean##'],
+                script: 'local.boolean##',
+                type: 'boolean'
+            }
+        ],
         help: 'create a reference to re-use the boolean'
     },
     {
@@ -227,12 +233,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable array## [array]'],
         script: 'local.array## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['array##'],
-            script: 'local.array## = {{1}}',
-            type: 'array'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['array##'],
+                script: 'local.array## = {{1}}',
+                type: 'array'
+            }
+        ],
         help: 'create a reference to re-use the array'
     },
     {
@@ -245,12 +253,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable object## [object]'],
         script: 'local.object## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['object##'],
-            script: 'local.object##',
-            type: 'object'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['object##'],
+                script: 'local.object##',
+                type: 'object'
+            }
+        ],
         help: 'create a reference to re-use the object'
     },
     {
@@ -263,12 +273,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable color## [color]'],
         script: 'local.color## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['color##'],
-            script: 'local.color##',
-            type: 'color'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['color##'],
+                script: 'local.color##',
+                type: 'color'
+            }
+        ],
         help: 'create a reference to re-use the color'
     },
     {
@@ -281,12 +293,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable image## [image]'],
         script: 'local.image## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['image##'],
-            script: 'local.image##',
-            type: 'image'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['image##'],
+                script: 'local.image##',
+                type: 'image'
+            }
+        ],
         help: 'create a reference to re-use the image'
     },
     {
@@ -300,12 +314,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable shape## [shape]'],
         script: 'local.shape## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['shape##'],
-            script: 'local.shape##',
-            type: 'shape'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['shape##'],
+                script: 'local.shape##',
+                type: 'shape'
+            }
+        ],
         help: 'create a reference to re-use the shape'
     },
     {
@@ -318,12 +334,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable point## [point]'],
         script: 'local.point## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['point##'],
-            script: 'local.point##',
-            type: 'point'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['point##'],
+                script: 'local.point##',
+                type: 'point'
+            }
+        ],
         help: 'create a reference to re-use the point'
     },
     {
@@ -336,12 +354,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable size## [size]'],
         script: 'local.size## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['size##'],
-            script: 'local.size##',
-            type: 'size'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['size##'],
+                script: 'local.size##',
+                type: 'size'
+            }
+        ],
         help: 'create a reference to re-use the size'
     },
     {
@@ -354,12 +374,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable rect## [rect]'],
         script: 'local.rect## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['rect##'],
-            script: 'local.rect##',
-            type: 'rect'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['rect##'],
+                script: 'local.rect##',
+                type: 'rect'
+            }
+        ],
         help: 'create a reference to re-use the rect'
     },
     {
@@ -372,12 +394,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable gradient## [gradient]'],
         script: 'local.gradient## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['gradient##'],
-            script: 'local.gradient##',
-            type: 'gradient'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['gradient##'],
+                script: 'local.gradient##',
+                type: 'gradient'
+            }
+        ],
         help: 'create a reference to re-use the gradient'
     },
     {
@@ -390,12 +414,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable pattern## [pattern]'],
         script: 'local.pattern## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['pattern##'],
-            script: 'local.pattern##',
-            type: 'pattern'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['pattern##'],
+                script: 'local.pattern##',
+                type: 'pattern'
+            }
+        ],
         help: 'create a reference to re-use the pattern'
     },
     {
@@ -408,12 +434,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable imagedata## [imagedata]'],
         script: 'local.imagedata## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['imagedata##'],
-            script: 'local.imagedata##',
-            type: 'imagedata'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['imagedata##'],
+                script: 'local.imagedata##',
+                type: 'imagedata'
+            }
+        ],
         help: 'create a reference to re-use the imagedata'
     },
     {
@@ -426,12 +454,14 @@ wb.menu('Variables', [
         blocktype: 'step',
         labels: ['variable any## [any]'],
         script: 'local.any## = {{1}};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['any##'],
-            script: 'local.any##',
-            type: 'any'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['any##'],
+                script: 'local.any##',
+                type: 'any'
+            }
+        ],
         help: 'create a reference to re-use the any'
     },
     {
@@ -473,24 +503,28 @@ wb.menu('Arrays', [
         labels: ['new array##'],
         script: 'local.array## = [];',
         help: 'Create an empty array',
-        returns: {
-            blocktype: 'expression',
-            labels: ['array##'],
-            script: 'local.array##',
-            type: 'array'
-        }
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['array##'],
+                script: 'local.array##',
+                type: 'array'
+            }
+        ]
     },
     {
         blocktype: 'step',
         labels: ['new array with array## [array]'],
         script: 'local.array## = {{1}}.slice();',
         help: 'create a new array with the contents of another array',
-        returns: {
-            blocktype: 'expression',
-            labels: ['array##'],
-            script: 'local.array##',
-            type: 'array'
-        }
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['array##'],
+                script: 'local.array##',
+                type: 'array'
+            }
+        ]
     },
     {
         blocktype: 'expression',
@@ -583,12 +617,14 @@ wb.menu('Objects', [
         blocktype: 'step',
         labels: ['new object##'],
         script: 'local.object## = {};',
-        returns: {
-            blocktype: 'expression',
-            labels: ['object##'],
-            script: 'local.object##',
-            type: 'object'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['object##'],
+                script: 'local.object##',
+                type: 'object'
+            }
+        ],
         help: 'create a new, empty object'
     },
     {
@@ -710,12 +746,14 @@ wb.menu('Sensing', [
         blocktype: 'step',
         labels: ['ask [string:What\'s your name?] and wait'],
         script: 'local.answer## = prompt({{1}});',
-        returns: {
-            blocktype: 'expression',
-            labels: ['answer##'],
-            type: 'string',
-            script: 'local.answer##'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['answer##'],
+                type: 'string',
+                script: 'local.answer##'
+            }
+        ],
         help: 'Prompt the user for information'
     },
     {

--- a/plugins/sprite.js
+++ b/plugins/sprite.js
@@ -36,12 +36,14 @@ wb.menu('Sprite', [
         blocktype: 'step',
         labels: ['rectangle sprite## [size] big at [point] with color [color]'],
         script: 'local.sprite## = new RectSprite({{1}}, {{2}}, {{3}});',
-        returns: {
-            blocktype: 'expression',
-            labels: ['sprite##'],
-            script: 'local.sprite##',
-            type: 'sprite'
-        },
+        locals: [
+            {
+                blocktype: 'expression',
+                labels: ['sprite##'],
+                script: 'local.sprite##',
+                type: 'sprite'
+            }
+        ],
         help: 'create a simple rectangle sprite'
     },
     {

--- a/plugins/twitter.js
+++ b/plugins/twitter.js
@@ -30,12 +30,14 @@ yepnope({
             blocktype: 'eventhandler',
             contained: [{label: 'get tweet for [string]'}],
             script: 'local.getTweet({{1}}, function(tweet){local.tweet## = tweet;[[1]]});',
-            returns: {
-                blocktype: 'expression',
-                label: 'last tweet##',
-                script: 'local.tweet## || "waiting…"',
-                type: 'string'
-            },
+            locals: [
+                {
+                    blocktype: 'expression',
+                    label: 'last tweet##',
+                    script: 'local.tweet## || "waiting…"',
+                    type: 'string'
+                }
+            ],
             help: 'asynchronous call to get the last tweet of the named account'
         }
     ]);


### PR DESCRIPTION
There is a known issue with this, which is that `next` blocks following a context end up in that context instead of their parent context. Since this is a long-standing issue, not a regression, and since we don't yet enforce scope, I think it's OK to go ahead with this fix.

In branch 212_unique_ids I'm fixing this, and scoping in general, and that should be ready soonish.
