### PR TITLE
Fixed a bug(feature?) where you could drag off the whole workspace.

### DIFF
--- a/scripts/drag.js
+++ b/scripts/drag.js
@@ -92,7 +92,7 @@
         // Called on mousedown or touchstart, we haven't started dragging yet
         // DONE: Don't start drag on a text input or select using :input jquery selector
         var eT = event.wbTarget;
-        if (wb.matches(eT, 'input, select, option, .disclosure')  && !wb.matches(eT, '#block_menu *')) {
+        if (wb.matches(eT, 'input, select, option, .disclosure,.scripts_workspace')  && !wb.matches(eT, '#block_menu *')) {
             console.log('not a drag handle');
             return undefined;
         }


### PR DESCRIPTION
I'm still getting the hang of git, so I thought I'd push something small for now.

I was having an issue where if I clicked and dragged a point in the workspace, it would drag everything away and crash waterbear.  This should fix that problem.
