### PR TITLE
Fixed a bug where the size of the text input field would reset to zero w...

### DIFF
--- a/scripts/util.js
+++ b/scripts/util.js
@@ -36,8 +36,8 @@
             input = input.wbTarget;
         }
         svgtext.textContent = input.value;
-        var width = svgtext.getComputedTextLength();
-        input.style.width = (width + 20) + 'px';
+        var textbox = svgtext.getBBox();
+        input.style.width = (textbox.width*0.7 + 25) + 'px';
     };
 
     // wb.mag = function mag(p1, p2){


### PR DESCRIPTION
Fixed a bug where the size of the text input would resize to zero when it was very long.  Also, the size of the text input field should more closely match the size of our text now.

The bit where it matches the font that we use is kind of a hack, but it looked like it was kind of a hack to begin with, and I couldn't think of a better way to do it, so whatever.  Note that the way that it is (and the way that it was) are fragile contingent on the font we are using.
