### PR TITLE
issue #333, Inputs requiring blocks shouldn't accept text

### DIFF
--- a/dist/arduino.js
+++ b/dist/arduino.js
@@ -1384,6 +1384,12 @@ function uuid(){
                 value = obj.uValue || obj.value || '';
         }
         var input = elem('input', {type: type, value: value});
+
+        //Only enable editing for the appropriate types
+        if (!(type === "string" || type === "any" || type === "number")) {
+            input.readOnly = true;
+        }
+
         wb.resize(input);
         return input;
     }

--- a/dist/javascript.js
+++ b/dist/javascript.js
@@ -3207,6 +3207,12 @@ function uuid(){
                 value = obj.uValue || obj.value || '';
         }
         var input = elem('input', {type: type, value: value});
+
+        //Only enable editing for the appropriate types
+        if (!(type === "string" || type === "any" || type === "number")) {
+            input.readOnly = true;
+        }
+
         wb.resize(input);
         return input;
     }

--- a/dist/minecraftjs.js
+++ b/dist/minecraftjs.js
@@ -3207,6 +3207,12 @@ function uuid(){
                 value = obj.uValue || obj.value || '';
         }
         var input = elem('input', {type: type, value: value});
+
+        //Only enable editing for the appropriate types
+        if (!(type === "string" || type === "any" || type === "number")) {
+            input.readOnly = true;
+        }
+
         wb.resize(input);
         return input;
     }

--- a/scripts/block.js
+++ b/scripts/block.js
@@ -462,6 +462,12 @@
                 value = obj.uValue || obj.value || '';
         }
         var input = elem('input', {type: type, value: value});
+
+        //Only enable editing for the appropriate types
+        if (!(type === "string" || type === "any" || type === "number")) {
+            input.readOnly = true;
+        }
+
         wb.resize(input);
         return input;
     }


### PR DESCRIPTION
This will make it so that only numbers, text, or any can be edited.
