### PR TITLE
fix menu links for processing.js examples

### DIFF
--- a/processingjs.html
+++ b/processingjs.html
@@ -46,15 +46,15 @@
 				<li>
 					<button class="show-examples">Examples</button>
 					<ul class="sub-menu">
-						<li><button class="load-example" data-href="/processingjs.html?example=ellipses">Ellipses</button></li>
-						<li><button class="load-example" data-href="/processingjs.html?example=lines">Lines</button></li>
-						<li><button class="load-example" data-href="/processingjs.html?example=mouse_click">Mouse Click</button></li>
-						<li><button class="load-example" data-href="/processingjs.html?example=mouse_rectangles">Mouse Rectangle</button></li>
-						<li><button class="load-example" data-href="/processingjs.html?example=nofill">No Fill</button></li>
-						<li><button class="load-example" data-href="/processingjs.html?example=rectangle">Rectangle</button></li>
-						<li><button class="load-example" data-href="/processingjs.html?example=transform">Transform</button></li>
-						<li><button class="load-example" data-href="/processingjs.html?example=transform_color">Transform Color</button></li>
-						<li><button class="load-example" data-href="/processingjs.html?example=variables">Variables</button></li>
+						<li><button class="load-example" data-example="ellipses">Ellipses</button></li>
+						<li><button class="load-example" data-example="lines">Lines</button></li>
+						<li><button class="load-example" data-example="mouse_click">Mouse Click</button></li>
+						<li><button class="load-example" data-example="mouse_rectangles">Mouse Rectangle</button></li>
+						<li><button class="load-example" data-example="nofill">No Fill</button></li>
+						<li><button class="load-example" data-example="rectangle">Rectangle</button></li>
+						<li><button class="load-example" data-example="transform">Transform</button></li>
+						<li><button class="load-example" data-example="transform_color">Transform Color</button></li>
+						<li><button class="load-example" data-example="variables">Variables</button></li>
 					</ul>
 				</li>
 				<li>


### PR DESCRIPTION
The example links in the ProcessingJS sandbox didn't work as expected.
This should fix it.
