### PR TITLE
issue 487: Enable removing a blcok from right-click menu

### DIFF
--- a/dist/arduino.js
+++ b/dist/arduino.js
@@ -2173,6 +2173,31 @@ function copyCommand(evt) {
 	action.redo();
 }
 
+function deleteCommand(evt) {
+	// console.log("Deleting a block!");
+	action = {
+		removed: this,
+		// Storing parent and next sibling in case removing the node from the DOM clears them
+		parent: this.parentNode,
+		before: this.nextSibling,
+		undo: function() {
+			// console.log(this);
+			if(wb.matches(this.removed,'.step')) {
+				this.parent.insertBefore(this.removed, this.before);
+			} else {
+				this.parent.appendChild(this.removed);
+			}
+			Event.trigger(this.removed, 'wb-add');
+		},
+		redo: function() {
+			Event.trigger(this.removed, 'wb-remove');
+			this.removed.remove();
+		},
+	}
+	wb.history.add(action);
+	action.redo();
+}
+
 function cutCommand(evt) {
 	// console.log("Cutting a block!");
 	action = {
@@ -2367,6 +2392,7 @@ var block_cmenu = {
 	//copySubscript: {name: 'Copy Subscript', callback: dummyCallback},
 	paste: {name: 'Paste', callback: pasteCommand, enabled: canPaste},
 	//cancel: {name: 'Cancel', callback: dummyCallback},
+        delete: {name: 'Delete', callback: deleteCommand},
 }
 
 // Test drawn from modernizr

--- a/dist/demo.js
+++ b/dist/demo.js
@@ -3996,6 +3996,31 @@ function copyCommand(evt) {
 	action.redo();
 }
 
+function deleteCommand(evt) {
+	// console.log("Deleting a block!");
+	action = {
+		removed: this,
+		// Storing parent and next sibling in case removing the node from the DOM clears them
+		parent: this.parentNode,
+		before: this.nextSibling,
+		undo: function() {
+			// console.log(this);
+			if(wb.matches(this.removed,'.step')) {
+				this.parent.insertBefore(this.removed, this.before);
+			} else {
+				this.parent.appendChild(this.removed);
+			}
+			Event.trigger(this.removed, 'wb-add');
+		},
+		redo: function() {
+			Event.trigger(this.removed, 'wb-remove');
+			this.removed.remove();
+		},
+	}
+	wb.history.add(action);
+	action.redo();
+}
+
 function cutCommand(evt) {
 	// console.log("Cutting a block!");
 	action = {
@@ -4190,6 +4215,7 @@ var block_cmenu = {
 	//copySubscript: {name: 'Copy Subscript', callback: dummyCallback},
 	paste: {name: 'Paste', callback: pasteCommand, enabled: canPaste},
 	//cancel: {name: 'Cancel', callback: dummyCallback},
+        delete: {name: 'Delete', callback: deleteCommand},
 }
 
 // Test drawn from modernizr

--- a/dist/javascript.js
+++ b/dist/javascript.js
@@ -3996,6 +3996,31 @@ function copyCommand(evt) {
 	action.redo();
 }
 
+function deleteCommand(evt) {
+	// console.log("Deleting a block!");
+	action = {
+		removed: this,
+		// Storing parent and next sibling in case removing the node from the DOM clears them
+		parent: this.parentNode,
+		before: this.nextSibling,
+		undo: function() {
+			// console.log(this);
+			if(wb.matches(this.removed,'.step')) {
+				this.parent.insertBefore(this.removed, this.before);
+			} else {
+				this.parent.appendChild(this.removed);
+			}
+			Event.trigger(this.removed, 'wb-add');
+		},
+		redo: function() {
+			Event.trigger(this.removed, 'wb-remove');
+			this.removed.remove();
+		},
+	}
+	wb.history.add(action);
+	action.redo();
+}
+
 function cutCommand(evt) {
 	// console.log("Cutting a block!");
 	action = {
@@ -4190,6 +4215,7 @@ var block_cmenu = {
 	//copySubscript: {name: 'Copy Subscript', callback: dummyCallback},
 	paste: {name: 'Paste', callback: pasteCommand, enabled: canPaste},
 	//cancel: {name: 'Cancel', callback: dummyCallback},
+        delete: {name: 'Delete', callback: deleteCommand},
 }
 
 // Test drawn from modernizr

--- a/dist/minecraftjs.js
+++ b/dist/minecraftjs.js
@@ -3996,6 +3996,31 @@ function copyCommand(evt) {
 	action.redo();
 }
 
+function deleteCommand(evt) {
+	// console.log("Deleting a block!");
+	action = {
+		removed: this,
+		// Storing parent and next sibling in case removing the node from the DOM clears them
+		parent: this.parentNode,
+		before: this.nextSibling,
+		undo: function() {
+			// console.log(this);
+			if(wb.matches(this.removed,'.step')) {
+				this.parent.insertBefore(this.removed, this.before);
+			} else {
+				this.parent.appendChild(this.removed);
+			}
+			Event.trigger(this.removed, 'wb-add');
+		},
+		redo: function() {
+			Event.trigger(this.removed, 'wb-remove');
+			this.removed.remove();
+		},
+	}
+	wb.history.add(action);
+	action.redo();
+}
+
 function cutCommand(evt) {
 	// console.log("Cutting a block!");
 	action = {
@@ -4190,6 +4215,7 @@ var block_cmenu = {
 	//copySubscript: {name: 'Copy Subscript', callback: dummyCallback},
 	paste: {name: 'Paste', callback: pasteCommand, enabled: canPaste},
 	//cancel: {name: 'Cancel', callback: dummyCallback},
+        delete: {name: 'Delete', callback: deleteCommand},
 }
 
 // Test drawn from modernizr

--- a/dist/processingjs.js
+++ b/dist/processingjs.js
@@ -14203,6 +14203,31 @@ function copyCommand(evt) {
 	action.redo();
 }
 
+function deleteCommand(evt) {
+	// console.log("Deleting a block!");
+	action = {
+		removed: this,
+		// Storing parent and next sibling in case removing the node from the DOM clears them
+		parent: this.parentNode,
+		before: this.nextSibling,
+		undo: function() {
+			// console.log(this);
+			if(wb.matches(this.removed,'.step')) {
+				this.parent.insertBefore(this.removed, this.before);
+			} else {
+				this.parent.appendChild(this.removed);
+			}
+			Event.trigger(this.removed, 'wb-add');
+		},
+		redo: function() {
+			Event.trigger(this.removed, 'wb-remove');
+			this.removed.remove();
+		},
+	}
+	wb.history.add(action);
+	action.redo();
+}
+
 function cutCommand(evt) {
 	// console.log("Cutting a block!");
 	action = {
@@ -14397,6 +14422,7 @@ var block_cmenu = {
 	//copySubscript: {name: 'Copy Subscript', callback: dummyCallback},
 	paste: {name: 'Paste', callback: pasteCommand, enabled: canPaste},
 	//cancel: {name: 'Cancel', callback: dummyCallback},
+        delete: {name: 'Delete', callback: deleteCommand},
 }
 
 // Test drawn from modernizr

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -142,6 +142,31 @@ function copyCommand(evt) {
 	action.redo();
 }
 
+function deleteCommand(evt) {
+	// console.log("Deleting a block!");
+	action = {
+		removed: this,
+		// Storing parent and next sibling in case removing the node from the DOM clears them
+		parent: this.parentNode,
+		before: this.nextSibling,
+		undo: function() {
+			// console.log(this);
+			if(wb.matches(this.removed,'.step')) {
+				this.parent.insertBefore(this.removed, this.before);
+			} else {
+				this.parent.appendChild(this.removed);
+			}
+			Event.trigger(this.removed, 'wb-add');
+		},
+		redo: function() {
+			Event.trigger(this.removed, 'wb-remove');
+			this.removed.remove();
+		},
+	}
+	wb.history.add(action);
+	action.redo();
+}
+
 function cutCommand(evt) {
 	// console.log("Cutting a block!");
 	action = {
@@ -336,6 +361,7 @@ var block_cmenu = {
 	//copySubscript: {name: 'Copy Subscript', callback: dummyCallback},
 	paste: {name: 'Paste', callback: pasteCommand, enabled: canPaste},
 	//cancel: {name: 'Cancel', callback: dummyCallback},
+        delete: {name: 'Delete', callback: deleteCommand},
 }
 
 // Test drawn from modernizr


### PR DESCRIPTION
tested against local server:
- clicking 'Delete' removes the block from script blocks and from script text
- clicking 'Delete' after 'Cut' doesn't affect the pasteboard
- 'Redo' and 'Undo' work as expected
