### PR TITLE
fixed bug #494

### DIFF
--- a/scripts/file.js
+++ b/scripts/file.js
@@ -199,6 +199,7 @@
 			}
 		}else{
 			//console.log('no script to load, starting a new script');	
+			wb.scriptLoaded = true;
 			wb.createWorkspace('Workspace');
 		}
 		wb.loaded = true;


### PR DESCRIPTION
When no script is loaded, and we create a new script,
we need to set wb.scriptLoaded to be true so the javascript_runtime.js loads
for new scripts.
