### PR TITLE
fix #683 refactor load from file/gist/example to be consistent

### DIFF
--- a/dist/arduino.js
+++ b/dist/arduino.js
@@ -1355,9 +1355,11 @@ var l10nFiles = {};
     }
 
     function resetSeqNum(){
+        console.log('resetSeqNum (and also block registry)');
         nextSeqNum = 0;
-        blockRegistry = {};
-        wb.blockRegistry = blockRegistry;
+        // the lines below were breaking loading from files, and probably any load after the menus were built
+        // blockRegistry = {};
+        // wb.blockRegistry = blockRegistry;
     }
 
     function registerBlock(blockdesc){
@@ -2343,15 +2345,22 @@ var l10nFiles = {};
             console.error('no json file found in gist: %o', gist);
             return;
         }
-        loadScriptsFromObject(JSON.parse(file));
+        loadScriptsFromJson(file);
     }
 
     function loadScriptsFromExample(name){
         ajax.get('examples/' + wb.language + '/' + name + '.json?b=' + Math.random(), function(exampleJson){
-            loadScriptsFromObject(JSON.parse(exampleJson));
+            loadScriptsFromJson(exampleJson);
         }, function(statusCode, xhr){
             console.error(statusCode + xhr);
         });
+    }
+
+    function loadScriptsFromJson(jsonblob){
+        // wb.clearScripts(null, true);
+        wb.loaded = true;
+        loadScriptsFromObject(JSON.parse(jsonblob));
+        wb.scriptModified = true;
     }
 
     function loadCurrentScripts(queryParsed){
@@ -2386,17 +2395,13 @@ var l10nFiles = {};
 	function loadScriptsFromFile(file){
 		var fileName = file.name;
 		if (fileName.indexOf('.json', fileName.length - 5) === -1) {
-			console.error("File not a JSON file");
+			console.error("File is not a JSON file");
 			return;
 		}
 		var reader = new FileReader();
 		reader.readAsText( file );
 		reader.onload = function (evt){
-			wb.clearScripts(null, true);
-			var saved = JSON.parse(evt.target.result);
-			wb.loaded = true;
-			loadScriptsFromObject(saved);
-			wb.scriptModified = true;
+            loadScriptsFromJson(evt.target.result);
 		};
 	}
 

--- a/dist/javascript.js
+++ b/dist/javascript.js
@@ -3178,9 +3178,11 @@ var l10nFiles = {};
     }
 
     function resetSeqNum(){
+        console.log('resetSeqNum (and also block registry)');
         nextSeqNum = 0;
-        blockRegistry = {};
-        wb.blockRegistry = blockRegistry;
+        // the lines below were breaking loading from files, and probably any load after the menus were built
+        // blockRegistry = {};
+        // wb.blockRegistry = blockRegistry;
     }
 
     function registerBlock(blockdesc){
@@ -4166,15 +4168,22 @@ var l10nFiles = {};
             console.error('no json file found in gist: %o', gist);
             return;
         }
-        loadScriptsFromObject(JSON.parse(file));
+        loadScriptsFromJson(file);
     }
 
     function loadScriptsFromExample(name){
         ajax.get('examples/' + wb.language + '/' + name + '.json?b=' + Math.random(), function(exampleJson){
-            loadScriptsFromObject(JSON.parse(exampleJson));
+            loadScriptsFromJson(exampleJson);
         }, function(statusCode, xhr){
             console.error(statusCode + xhr);
         });
+    }
+
+    function loadScriptsFromJson(jsonblob){
+        // wb.clearScripts(null, true);
+        wb.loaded = true;
+        loadScriptsFromObject(JSON.parse(jsonblob));
+        wb.scriptModified = true;
     }
 
     function loadCurrentScripts(queryParsed){
@@ -4209,17 +4218,13 @@ var l10nFiles = {};
 	function loadScriptsFromFile(file){
 		var fileName = file.name;
 		if (fileName.indexOf('.json', fileName.length - 5) === -1) {
-			console.error("File not a JSON file");
+			console.error("File is not a JSON file");
 			return;
 		}
 		var reader = new FileReader();
 		reader.readAsText( file );
 		reader.onload = function (evt){
-			wb.clearScripts(null, true);
-			var saved = JSON.parse(evt.target.result);
-			wb.loaded = true;
-			loadScriptsFromObject(saved);
-			wb.scriptModified = true;
+            loadScriptsFromJson(evt.target.result);
 		};
 	}
 

--- a/dist/node.js
+++ b/dist/node.js
@@ -3178,9 +3178,11 @@ var l10nFiles = {};
     }
 
     function resetSeqNum(){
+        console.log('resetSeqNum (and also block registry)');
         nextSeqNum = 0;
-        blockRegistry = {};
-        wb.blockRegistry = blockRegistry;
+        // the lines below were breaking loading from files, and probably any load after the menus were built
+        // blockRegistry = {};
+        // wb.blockRegistry = blockRegistry;
     }
 
     function registerBlock(blockdesc){
@@ -4166,15 +4168,22 @@ var l10nFiles = {};
             console.error('no json file found in gist: %o', gist);
             return;
         }
-        loadScriptsFromObject(JSON.parse(file));
+        loadScriptsFromJson(file);
     }
 
     function loadScriptsFromExample(name){
         ajax.get('examples/' + wb.language + '/' + name + '.json?b=' + Math.random(), function(exampleJson){
-            loadScriptsFromObject(JSON.parse(exampleJson));
+            loadScriptsFromJson(exampleJson);
         }, function(statusCode, xhr){
             console.error(statusCode + xhr);
         });
+    }
+
+    function loadScriptsFromJson(jsonblob){
+        // wb.clearScripts(null, true);
+        wb.loaded = true;
+        loadScriptsFromObject(JSON.parse(jsonblob));
+        wb.scriptModified = true;
     }
 
     function loadCurrentScripts(queryParsed){
@@ -4209,17 +4218,13 @@ var l10nFiles = {};
 	function loadScriptsFromFile(file){
 		var fileName = file.name;
 		if (fileName.indexOf('.json', fileName.length - 5) === -1) {
-			console.error("File not a JSON file");
+			console.error("File is not a JSON file");
 			return;
 		}
 		var reader = new FileReader();
 		reader.readAsText( file );
 		reader.onload = function (evt){
-			wb.clearScripts(null, true);
-			var saved = JSON.parse(evt.target.result);
-			wb.loaded = true;
-			loadScriptsFromObject(saved);
-			wb.scriptModified = true;
+            loadScriptsFromJson(evt.target.result);
 		};
 	}
 

--- a/dist/processingjs.js
+++ b/dist/processingjs.js
@@ -13385,9 +13385,11 @@ var l10nFiles = {};
     }
 
     function resetSeqNum(){
+        console.log('resetSeqNum (and also block registry)');
         nextSeqNum = 0;
-        blockRegistry = {};
-        wb.blockRegistry = blockRegistry;
+        // the lines below were breaking loading from files, and probably any load after the menus were built
+        // blockRegistry = {};
+        // wb.blockRegistry = blockRegistry;
     }
 
     function registerBlock(blockdesc){
@@ -14373,15 +14375,22 @@ var l10nFiles = {};
             console.error('no json file found in gist: %o', gist);
             return;
         }
-        loadScriptsFromObject(JSON.parse(file));
+        loadScriptsFromJson(file);
     }
 
     function loadScriptsFromExample(name){
         ajax.get('examples/' + wb.language + '/' + name + '.json?b=' + Math.random(), function(exampleJson){
-            loadScriptsFromObject(JSON.parse(exampleJson));
+            loadScriptsFromJson(exampleJson);
         }, function(statusCode, xhr){
             console.error(statusCode + xhr);
         });
+    }
+
+    function loadScriptsFromJson(jsonblob){
+        // wb.clearScripts(null, true);
+        wb.loaded = true;
+        loadScriptsFromObject(JSON.parse(jsonblob));
+        wb.scriptModified = true;
     }
 
     function loadCurrentScripts(queryParsed){
@@ -14416,17 +14425,13 @@ var l10nFiles = {};
 	function loadScriptsFromFile(file){
 		var fileName = file.name;
 		if (fileName.indexOf('.json', fileName.length - 5) === -1) {
-			console.error("File not a JSON file");
+			console.error("File is not a JSON file");
 			return;
 		}
 		var reader = new FileReader();
 		reader.readAsText( file );
 		reader.onload = function (evt){
-			wb.clearScripts(null, true);
-			var saved = JSON.parse(evt.target.result);
-			wb.loaded = true;
-			loadScriptsFromObject(saved);
-			wb.scriptModified = true;
+            loadScriptsFromJson(evt.target.result);
 		};
 	}
 

--- a/scripts/block.js
+++ b/scripts/block.js
@@ -40,9 +40,11 @@
     }
 
     function resetSeqNum(){
+        console.log('resetSeqNum (and also block registry)');
         nextSeqNum = 0;
-        blockRegistry = {};
-        wb.blockRegistry = blockRegistry;
+        // the lines below were breaking loading from files, and probably any load after the menus were built
+        // blockRegistry = {};
+        // wb.blockRegistry = blockRegistry;
     }
 
     function registerBlock(blockdesc){

--- a/scripts/file.js
+++ b/scripts/file.js
@@ -183,15 +183,22 @@
             console.error('no json file found in gist: %o', gist);
             return;
         }
-        loadScriptsFromObject(JSON.parse(file));
+        loadScriptsFromJson(file);
     }
 
     function loadScriptsFromExample(name){
         ajax.get('examples/' + wb.language + '/' + name + '.json?b=' + Math.random(), function(exampleJson){
-            loadScriptsFromObject(JSON.parse(exampleJson));
+            loadScriptsFromJson(exampleJson);
         }, function(statusCode, xhr){
             console.error(statusCode + xhr);
         });
+    }
+
+    function loadScriptsFromJson(jsonblob){
+        // wb.clearScripts(null, true);
+        wb.loaded = true;
+        loadScriptsFromObject(JSON.parse(jsonblob));
+        wb.scriptModified = true;
     }
 
     function loadCurrentScripts(queryParsed){
@@ -226,17 +233,13 @@
 	function loadScriptsFromFile(file){
 		var fileName = file.name;
 		if (fileName.indexOf('.json', fileName.length - 5) === -1) {
-			console.error("File not a JSON file");
+			console.error("File is not a JSON file");
 			return;
 		}
 		var reader = new FileReader();
 		reader.readAsText( file );
 		reader.onload = function (evt){
-			wb.clearScripts(null, true);
-			var saved = JSON.parse(evt.target.result);
-			wb.loaded = true;
-			loadScriptsFromObject(saved);
-			wb.scriptModified = true;
+            loadScriptsFromJson(evt.target.result);
 		};
 	}
 


### PR DESCRIPTION
Refactored so that loading from any JSON blob (file, gist, example) runs through the same code path. Now if we have a bug with one of them, at least it will be a bug with all of them.
