### PR TITLE
add min/max to block definitions

### DIFF
--- a/languages/javascript/blocks/array_blockmenu.js
+++ b/languages/javascript/blocks/array_blockmenu.js
@@ -67,7 +67,8 @@
             {
                 "name": "item",
                 "type": "number",
-                "value": 0
+                "value": 0,
+                "min": 0
             }
             ]
         },
@@ -149,7 +150,8 @@
             {
                 "name": "remove item",
                 "type": "number",
-                "value": 0
+                "value": 0,
+                "min": 0
             }
             ]
         },
@@ -165,7 +167,8 @@
                 {
                     "name": "remove item",
                     "type": "number",
-                    "value": 0
+                    "value": 0,
+                    "min": 0
                 }
             ]
         },

--- a/languages/javascript/blocks/canvas_blockmenu.js
+++ b/languages/javascript/blocks/canvas_blockmenu.js
@@ -48,7 +48,9 @@
                         {
                             "name": "global alpha",
                             "type": "number",
-                            "value": 1.0
+                            "value": 1.0,
+                            "min": 0.0,
+                            "max": 1.0
                         }
                     ]
                 },
@@ -126,6 +128,7 @@
                             "name": "line width",
                             "type": "number",
                             "value": 1
+                            "min": 0
                         }
                     ]
                 },
@@ -166,7 +169,8 @@
                         {
                             "name": "mitre limit",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 0.0
                         }
                     ]
                 },
@@ -197,7 +201,8 @@
                         {
                             "name": "shadow blur",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0
                         }
                     ]
                 },
@@ -228,7 +233,8 @@
                         {
                             "name": "with radius",
                             "type": "number",
-                            "value": "10"
+                            "value": 10,
+                            "min": 0
                         }
                     ],
                     "tags": ["shape", "circle", "stroke"]
@@ -270,7 +276,8 @@
                         {
                             "name": "and width",
                             "type": "number",
-                            "value": 1
+                            "value": 1,
+                            "min": 0
                         }
                     ]
                 }

--- a/languages/javascript/blocks/color_blockmenu.js
+++ b/languages/javascript/blocks/color_blockmenu.js
@@ -245,6 +245,8 @@
                             "name": "grey with level",
                             "type": "number",
                             "value": 100
+                            "min": 0,
+                            "max": 255
                         }
                     ]
                 },
@@ -259,16 +261,22 @@
                             "name": "color with red",
                             "type": "number",
                             "value": 0
+                            "min": 0,
+                            "max": 255
                         },
                         {
                             "name": "green",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0,
+                            "max": 255
                         },
                         {
                             "name": "blue",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0,
+                            "max": 255
                         }
                     ]
                 },
@@ -282,22 +290,30 @@
                         {
                             "name": "color with red",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0,
+                            "max": 255
                         },
                         {
                             "name": "green",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0,
+                            "max": 255
                         },
                         {
                             "name": "blue",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0,
+                            "max": 255
                         },
                         {
                             "name": "alpha",
                             "type": "number",
-                            "value": 0.1
+                            "value": 0.1,
+                            "min": 0.0,
+                            "max": 1.0
                         }
                     ]
                 },
@@ -311,17 +327,26 @@
                         {
                             "name": "color with hue",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0,
+                            "max": 360,
+                            "suffix": "°"
                         },
                         {
                             "name": "saturation",
                             "type": "number",
                             "value": 0
+                            "min": 0,
+                            "max": 100,
+                            "suffix": "%"
                         },
                         {
                             "name": "brightness",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0,
+                            "max": 100,
+                            "suffix": "%"
                         }
                     ]
                 },
@@ -410,7 +435,8 @@
                         {
                             "name": "radius1",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0
                         },
                         {
                             "name": "to point2",
@@ -419,7 +445,8 @@
                         {
                             "name": "radius2",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0
                         }
                     ]
                 },
@@ -464,7 +491,9 @@
                         {
                             "name": "at offset",
                             "type": "number",
-                            "value": 0.5
+                            "value": 0.5,
+                            "min": 0.0,
+                            "max": 1.0
                         },
                         {
                             "name": "with color",

--- a/languages/javascript/blocks/control_blockmenu.js
+++ b/languages/javascript/blocks/control_blockmenu.js
@@ -106,7 +106,8 @@
                         {
                             "name": "repeat",
                             "type": "number",
-                            "value": "30"
+                            "value": 30,
+                            "min": 0
                         },
                         {
                             "name": "times a second until",
@@ -181,7 +182,8 @@
                         {
                             "name": "schedule in",
                             "type": "number",
-                            "value": "1"
+                            "value": 1,
+                            "min": 0
                         },
                         {
                             "name": "secs"
@@ -209,7 +211,8 @@
                         {
                             "name": "repeat",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 0
                         }
                     ]
                 },

--- a/languages/javascript/blocks/geolocation_blockmenu.js
+++ b/languages/javascript/blocks/geolocation_blockmenu.js
@@ -39,7 +39,8 @@
                         {
                             "name": "when within",
                             "type": "number",
-                            "value": 1
+                            "value": 1,
+                            "min": 0
                         },
                         {
                             "name": "km of",

--- a/languages/javascript/blocks/math_blockmenu.js
+++ b/languages/javascript/blocks/math_blockmenu.js
@@ -16,12 +16,12 @@
                         {
                             "name": "",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "× 10 ^",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         }
                     ],
                     "keywords": [
@@ -157,12 +157,12 @@
                         {
                             "name": "",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "≠",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         }
                     ],
                     "keywords": [
@@ -203,12 +203,11 @@
                         {
                             "name": "",
                             "type": "number",
-                            "value": "0"
-                        },
+                            "value": 0                        },
                         {
                             "name": "≤",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         }
                     ],
                     "keywords": [
@@ -249,12 +248,12 @@
                         {
                             "name": "",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "≥",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         }
                     ],
                     "keywords": [
@@ -830,12 +829,12 @@
                         {
                             "name": "bitwise",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "and",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         }
                     ],
                     "keywords": [
@@ -853,12 +852,12 @@
                         {
                             "name": "bitwise",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "or",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         }
                     ],
                     "keywords": [
@@ -876,12 +875,12 @@
                         {
                             "name": "bitwise",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "xor",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         }
                     ],
                     "keywords": [
@@ -899,12 +898,12 @@
                         {
                             "name": "bitwise",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "nand",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         }
                     ],
                     "keywords": [
@@ -922,12 +921,12 @@
                         {
                             "name": "bit shift",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "left by",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "bits"
@@ -948,12 +947,12 @@
                         {
                             "name": "bit shift",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "right by",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "bits"
@@ -976,7 +975,7 @@
                 {
                     "name": "Summation",
                     "type": "number",
-                    "value": "0"
+                    "value": 0
                 }
             ],
             "keywords": [
@@ -997,12 +996,12 @@
                 {
                     "name": "from ",
                     "type": "number",
-                    "value": "0"
+                    "value": 0
                 },
                 {
                     "name": "to",
                     "type": "number",
-                    "value": "0"
+                    "value": 0
                 }
             ]
         },
@@ -1019,12 +1018,12 @@
                 {
                     "name": "First ",
                     "type": "number",
-                    "value": "0"
+                    "value": 0
                 },
                 {
                     "name": "multiples of",
                     "type": "number",
-                    "value": "0"
+                    "value": 0
                 }
             ],
             "keywords": [

--- a/languages/javascript/blocks/path_blockmenu.js
+++ b/languages/javascript/blocks/path_blockmenu.js
@@ -95,6 +95,7 @@
                             "name": "with radius",
                             "type": "number",
                             "value": 1.0
+                            "min": 0.0
                         }
                     ]
                 },
@@ -110,20 +111,24 @@
                         },
                         {
                             "name": "radius",
-                            "type": "number"
+                            "type": "number",
+                            "value": "1",
+                            "min": 0
                         },
                         {
                             "name": "start angle",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "suffix": "degrees"
                         },
                         {
-                            "name": "deg, end angle",
+                            "name": "end angle",
                             "type": "number",
                             "value": 45
-                        },
+                            "suffix" "degrees"
+                        }
                         {
-                            "name": "deg",
+                            "name": "anticlockwise",
                             "type": "boolean",
                             "value": true
                         }
@@ -155,6 +160,7 @@
                             "name": "with radius",
                             "type": "number",
                             "value": 10
+                            "min": 0
                         }
                     ]
                 },

--- a/languages/javascript/blocks/rect_blockmenu.js
+++ b/languages/javascript/blocks/rect_blockmenu.js
@@ -26,12 +26,14 @@
                         {
                             "name": "with width",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 0
                         },
                         {
                             "name": "height",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 0
                         }
                     ],
                     "tags": [

--- a/languages/javascript/blocks/shape_blockmenu.js
+++ b/languages/javascript/blocks/shape_blockmenu.js
@@ -36,7 +36,8 @@
                         {
                             "name": "with radius",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 0
                         }
                     ],
                     "tags": [
@@ -56,7 +57,8 @@
                         {
                             "name": "with radius",
                             "type": "number",
-                            "value": 30
+                            "value": 30,
+                            "min": 0
                         },
                         {
                             "name": "and color",
@@ -82,7 +84,8 @@
                         {
                             "name": "with radius",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 0
                         }
                     ],
                     "tags": [
@@ -102,7 +105,8 @@
                         {
                             "name": "with radius",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 0
                         },
                         {
                             "name": "and color",
@@ -127,7 +131,8 @@
                         {
                             "name": "with radius",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 0
                         }
                     ],
                     "tags": [
@@ -183,7 +188,8 @@
                         {
                             "name": "with border-radius",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0
                         },
                         {
                             "name": "and color",
@@ -250,12 +256,14 @@
                         {
                             "name": "width",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 0
                         },
                         {
                             "name": "height",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 0
                         }
                     ],
                     "tags": [
@@ -311,17 +319,18 @@
                         {
                             "name": "circle at x",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "y",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "with radius",
                             "type": "number",
-                            "value": "10"
+                            "value": 10,
+                            "min": 0
                         }
                     ]
                 },
@@ -333,8 +342,7 @@
                     "sockets": [
                         {
                             "name": "polygon with points ",
-                            "type": "array",
-                            "value": null
+                            "type": "array"
                         }
                     ]
                 },
@@ -347,27 +355,30 @@
                         {
                             "name": "rect at x",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "y",
                             "type": "number",
-                            "value": "0"
+                            "value": 0
                         },
                         {
                             "name": "with width",
                             "type": "number",
-                            "value": "10"
+                            "value": 10,
+                            "min": 0
                         },
                         {
                             "name": "height",
                             "type": "number",
-                            "value": "10"
+                            "value": 10,
+                            "min": 0
                         },
                         {
                             "name": "border-radius",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0
                         }
                     ]
                 },
@@ -379,18 +390,17 @@
                     "sockets": [
                         {
                             "name": "rect at point",
-                            "type": "point",
-                            "value": null
+                            "type": "point"
                         },
                         {
                             "name": "with size",
-                            "type": "size",
-                            "value": null
+                            "type": "size"
                         },
                         {
                             "name": "border-radius",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0
                         }
                     ]
                 },
@@ -402,8 +412,7 @@
                     "sockets": [
                         {
                             "name": "rect from array",
-                            "type": "array",
-                            "value": null
+                            "type": "array"
                         }
                     ]
                 }

--- a/languages/javascript/blocks/size_blockmenu.js
+++ b/languages/javascript/blocks/size_blockmenu.js
@@ -15,7 +15,8 @@
                         {
                             "name": "size with width",
                             "type": "number",
-                            "value": 32
+                            "value": 32,
+                            "min": 0
                         },
                         {
                             "name": "width units",
@@ -26,7 +27,8 @@
                         {
                             "name": "height",
                             "type": "number",
-                            "value": 32
+                            "value": 32,
+                            "min": 0
                         },
                         {
                             "name": "height units",

--- a/languages/javascript/blocks/sprite_blockmenu.js
+++ b/languages/javascript/blocks/sprite_blockmenu.js
@@ -223,10 +223,8 @@
                         {
                             "name": "by",
                             "type": "number",
-                            "value": 0
-                        },
-                        {
-                            "name": "degrees"
+                            "value": 0,
+                            "suffix": "degrees"
                         }
                     ]
                 },
@@ -261,10 +259,8 @@
                         {
                             "name": "by",
                             "type": "number",
-                            "value": 0
-                        },
-                        {
-                            "name": "degrees"
+                            "value": 0,
+                            "suffix": "degrees"
                         }
                     ]
                 },
@@ -281,10 +277,8 @@
                         {
                             "name": "to",
                             "type": "number",
-                            "value": 0
-                        },
-                        {
-                            "name": "degrees"
+                            "value": 0,
+                            "suffix": "degrees"
                         }
                     ]
                 },

--- a/languages/javascript/blocks/string_blockmenu.js
+++ b/languages/javascript/blocks/string_blockmenu.js
@@ -57,7 +57,8 @@
                         {
                             "name": "",
                             "type": "number",
-                            "value": "2"
+                            "value": 2,
+                            "min": 0
                         },
                         {
                             "name": "times"
@@ -78,7 +79,8 @@
                         {
                             "name": "character at",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0
                         }
                     ]
                 },
@@ -97,7 +99,8 @@
                         {
                             "name": "character at",
                             "type": "number",
-                            "value": "0"
+                            "value": 0,
+                            "min": 0
                         },
                         {
                             "name": "from the end"
@@ -119,12 +122,14 @@
                         {
                             "name": "substring at",
                             "type": "number",
-                            "value": "0"
+                            "value": 0,
+                            "min": 0
                         },
                         {
                             "name": "of length",
                             "type": "number",
-                            "value": "0"
+                            "value": 0,
+                            "min": 0
                         }
                     ]
                 },
@@ -143,12 +148,14 @@
                         {
                             "name": "substring from",
                             "type": "number",
-                            "value": "0"
+                            "value": 0,
+                            "min": 0
                         },
                         {
                             "name": "to",
                             "type": "number",
-                            "value": "0"
+                            "value": 0,
+                            "min": 0
                         }
                     ]
                 },

--- a/languages/javascript/blocks/text_blockmenu.js
+++ b/languages/javascript/blocks/text_blockmenu.js
@@ -15,7 +15,8 @@
                         {
                             "name": "font",
                             "type": "number",
-                            "value": 10
+                            "value": 10,
+                            "min": 6
                         },
                         {
                             "name": "",

--- a/languages/javascript/blocks/vector_blockmenu.js
+++ b/languages/javascript/blocks/vector_blockmenu.js
@@ -28,7 +28,7 @@
                             "name": "vector##",
                             "type": "number",
                             "value": 0,
-                            "suffix": "x,"
+                            "suffix": "x"
                         },
                         {
                             "name": "",

--- a/languages/javascript/blocks/voice_blockmenu.js
+++ b/languages/javascript/blocks/voice_blockmenu.js
@@ -43,6 +43,8 @@
                             "name": "tone",
                             "type": "number",
                             "value": 440,
+                            "min": 20,
+                            "max": 20000,
                             "suffix": "Hz"
                         }
                     ]
@@ -78,7 +80,8 @@
                         {
                             "name": "volume",
                             "type": "number",
-                            "value": 1
+                            "value": 1,
+                            "min": 0
                         }
                     ]
                 },
@@ -96,6 +99,7 @@
                             "name": "tempo quarter note =",
                             "type": "number",
                             "value": 120,
+                            "min": 0,
                             "suffix": "beats per minute"
                         }
                     ]
@@ -154,6 +158,7 @@
                             "name": "for ",
                             "type": "number",
                             "value": 2,
+                            "min": 0,
                             "suffix": "seconds"
                         }
                     ]
@@ -183,7 +188,8 @@
                         {
                             "name": "dotted",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0
                         }
                     ]
                 },
@@ -206,7 +212,8 @@
                         {
                             "name": "dotted",
                             "type": "number",
-                            "value": 0
+                            "value": 0,
+                            "min": 0
                         }
                     ]
                 },


### PR DESCRIPTION
Also prevents numeric fields from having non-numeric or otherwise invalid values. Fixes #791 and #334.
