### PR TITLE
Use appropriate cursor changes in the editor

### DIFF
--- a/css/block.css
+++ b/css/block.css
@@ -135,6 +135,7 @@ wb-context > header > wb-disclosure:after{
     position: absolute;
     top: 5px;
     left: 0px;
+    cursor: default;
 }
 
 wb-context[closed] > header > wb-disclosure:after{

--- a/css/block.css
+++ b/css/block.css
@@ -34,7 +34,16 @@ wb-value select{
 wb-step.dragging, wb-context.dragging, wb-expression.dragging{
     opacity: 0.5;
     position: absolute;
+    /* Necessary for dragging events. */
     pointer-events: none;
+}
+
+/* This class is probably added on the body or the workspace container. */
+.block-dragging {
+    cursor: move !important;
+    /* More appropriate, but less compatible. */
+    cursor: -moz-grabbing !important;
+    cursor: -webkit-grabbing !important;
 }
 
 wb-expression > header{

--- a/css/block.css
+++ b/css/block.css
@@ -10,7 +10,11 @@ wb-step, wb-context, wb-expression{
     float: left;
     clear: left;
     position: relative;
+}
 
+body:not(.block-dragging) wb-step,
+body:not(.block-dragging) wb-context,
+body:not(.block-dragging) wb-expression {
     cursor: move;
     /* More appropriate, but less compatible. */
     cursor: -moz-grab;
@@ -40,10 +44,10 @@ wb-step.dragging, wb-context.dragging, wb-expression.dragging{
 
 /* This class is probably added on the body or the workspace container. */
 .block-dragging {
-    cursor: move !important;
+    cursor: move;
     /* More appropriate, but less compatible. */
-    cursor: -moz-grabbing !important;
-    cursor: -webkit-grabbing !important;
+    cursor: -moz-grabbing;
+    cursor: -webkit-grabbing;
 }
 
 wb-expression > header{

--- a/css/block.css
+++ b/css/block.css
@@ -10,6 +10,11 @@ wb-step, wb-context, wb-expression{
     float: left;
     clear: left;
     position: relative;
+
+    cursor: move;
+    /* More appropriate, but less compatible. */
+    cursor: -moz-grab;
+    cursor: -webkit-grab;
 }
 
 wb-expression{

--- a/js/block.js
+++ b/js/block.js
@@ -553,6 +553,7 @@ var dropTarget = null;
 var BLOCK_MENU = document.querySelector('sidebar');
 var blockTop = 0;
 
+/* When the block has started to be dragged. */
 Event.on(document.body, 'drag-start', 'wb-step, wb-step *, wb-context, wb-context *, wb-expression, wb-expression *', function(evt){
     origTarget = dom.closest(evt.target, 'wb-step, wb-context, wb-expression');
     // Maybe move to object notation later
@@ -561,6 +562,9 @@ Event.on(document.body, 'drag-start', 'wb-step, wb-step *, wb-context, wb-contex
     // Show trash can, should be in app.js, not block.js
     blockTop = BLOCK_MENU.scrollTop;
     BLOCK_MENU.classList.add('trashcan');
+
+    // Add a dragging class for extra styles (e.g., dragging cursor).
+    document.body.classList.add('block-dragging');
 
     // FIXME: Highlight droppable places (or grey out non-droppable)
 
@@ -702,6 +706,8 @@ function resetDragging(){
     // Hide trash can, should be in app.js, not block.js
     BLOCK_MENU.classList.remove('trashcan');
     BLOCK_MENU.scrollTop = blockTop;
+    // Remove dragging class.
+    document.body.classList.remove('block-dragging');
 }
 
 


### PR DESCRIPTION
Uses appropriate drag/dragging cursors for blocks in the new GUI. Adds a `block-dragging` class when... you drag a block.

This will close  #344.