### PR TITLE
force sidebar to scroll selected accordion into view

### DIFF
--- a/js/widget.js
+++ b/js/widget.js
@@ -29,6 +29,8 @@ AccordionProto.open = function(){
         existing.close();
     }
     this.setAttribute('open', 'true');
+    this.scrollIntoView();
+    
 }
 
 AccordionProto.close = function(){


### PR DESCRIPTION
Added a line in the function which handles opening accordions so that, if the header of the selected accordion will not be in view upon opening, the sidebar will scroll so that it is at the top of the pane