### PR TITLE
462 query params

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -747,6 +747,7 @@ Event.on(document.body, 'input', 'input', function(evt){
     var target = evt.target;
     if (! dom.matches(target, 'wb-value > input')) return;
     resize(target);
+    Event.trigger(target, 'wb-changed', evt.target.value);
 }, false);
 
 

--- a/js/queryparams.js
+++ b/js/queryparams.js
@@ -41,7 +41,11 @@
         return base + '?' + parts.join('&');
     }
 
-    wb.urlToQueryParams = urlToQueryParams;
-    wb.queryParamsToUrl = queryParamsToUrl;
-    runtime.wb = wb;
+    runtime.query = {
+        params: function (){
+            return urlToQueryParams(location.toString());
+        },
+        urlToQueryParams: urlToQueryParams,
+        queryParamsToUrl: queryParamsToUrl
+    };
 })(this);

--- a/playground.html
+++ b/playground.html
@@ -784,7 +784,7 @@
                 </header>
                 <wb-context script="motion.whenDeviceTurned">
                     <wb-value type="list" allow="literal" options="upright,downright,downleft,upleft,up,down,right,left">when device turned</wb-value>
-                    
+
                 </wb-context>
                 <wb-expression type="motion" script="motion.tiltDirection">
                     tilt direction
@@ -952,6 +952,7 @@
     <script src="js/block.js"></script>
 	<script src="js/app.js"></script>
     <script src="js/file.js"></script>
+    <script src="js/queryparams.js"></script>
     <script>
         <!-- Google Analytics -->
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Minimal implementation of query params.

* Handles example and gist params only (on load)
* Sets gist param when you  save a gist or load from gist
* Clears gist param on any script change

Does not handle back button or layout params. Deferring layout params until we have UI code to support them. Back button requires state management that got really gnarly in old-waterbear, not sure if we even want to go there.