### PR TITLE
fix overflow problems in firefox

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -3,6 +3,7 @@
 html, body{
     width:100%;
     height:100%;
+    overflow: hidden;
     background: #fff;
 }
 

--- a/css/widget.css
+++ b/css/widget.css
@@ -11,6 +11,7 @@ wb-hbox, wb-vbox{
     display: flex;
     flex: 1 1;
     position: relative;
+    overflow: hidden;
 }
 wb-hbox{
     flex-direction: row;


### PR DESCRIPTION
In Firefox, the <body> was pushed down and scrolling the sidebar scrolled the whole page. This should fix it, and doesn't break Chrome.