### PR TITLE
added `clear stage to [color,image]`

### DIFF
--- a/css/block.css
+++ b/css/block.css
@@ -81,7 +81,7 @@ wb-value > * {
 
 
 wb-value > input[type=color]{
-    padding: 0;
+    padding: 0 0 0 20px ;
 }
 
 wb-unit{
@@ -232,7 +232,7 @@ wb-expression[type=sprite]:before{ background-image: url(../images/icon/sprite.s
 wb-expression[type=any]:before{ background-image: url(../images/icon/control.svg); }
 wb-expression[type=sound]:before{ background-image: url(../images/icon/sound.svg); }
 wb-expression[type=array]:before{ background-image: url(../images/icon/array.svg); }
-wb-expression[type=image]:before{ background-image: url(../images/icon/image.svg); }
+wb-expression[type=wb-image]:before{ background-image: url(../images/icon/image.svg); }
 wb-expression[type=shape]:before{ background-image: url(../images/icon/shape.svg); }
 wb-expression[type=vector]:before{ background-image: url(../images/icon/vector.svg); }
 wb-expression[type=object]:before{ background-image: url(../images/icon/object.svg); }
@@ -277,7 +277,7 @@ wb-expression[type=sprite],wb-local wb-expression[type=sprite]{ background-color
 wb-expression[type=any],wb-local wb-expression[type=any]{ background-color: hsl(0, 93%, 56%); border-color: hsl(0, 93%, 40%); }
 wb-expression[type=sound],wb-local wb-expression[type=sound]{ background-color: hsl(108, 93%, 56%); border-color: hsl(108, 93%, 40%); }
 wb-expression[type=array],wb-local wb-expression[type=array]{ background-color: hsl(264, 93%, 56%); border-color: hsl(264, 93%, 40%); }
-wb-expression[type=image],wb-local wb-expression[type=image]{ background-color: hsl(168, 93%, 56%); border-color: hsl(168, 93%, 40%); }
+wb-expression[type=wb-image],wb-local wb-expression[type=wb-image]{ background-color: hsl(168, 93%, 56%); border-color: hsl(168, 93%, 40%); }
 wb-expression[type=shape],wb-local wb-expression[type=shape]{ background-color: hsl(84, 93%, 56%); border-color: hsl(84, 93%, 40%); }
 wb-expression[type=vector],wb-local wb-expression[type=vector]{ background-color: hsl(276, 93%, 56%); border-color: hsl(276, 93%, 40%); }
 wb-expression[type=object],wb-local wb-expression[type=object]{ background-color: hsl(72, 93%, 56%); border-color: hsl(72, 93%, 40%); }

--- a/css/widget.css
+++ b/css/widget.css
@@ -99,7 +99,7 @@ wb-search{
 /* ACCORDION */
 
 wb-accordion{
-    overflow: visible;
+    overfow: visible;
     padding-left: 6px;
 }
 

--- a/js/dom.js
+++ b/js/dom.js
@@ -53,6 +53,14 @@
         return elem; // for chaining
     }
 
+    var cloner = document.createElement('div');
+    function clone(elem){
+        // Cloned custom elements in Firefox do not preserve custom element lifecycle events
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1050113
+        cloner.innerHTML = elem.outerHTML;
+        return cloner.removeChild(cloner.firstChild);
+    }
+
     function appendChildren(e, children){
         // Children can be a single child or an array
         // Each child can be a string or a node
@@ -247,6 +255,7 @@
         html: html,
         svg: svg,
         elemToObj: elemToObject,
+        clone: clone,
         remove: remove,
         insertAfter: insertAfter,
         matches: matches,

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -177,32 +177,6 @@
                 return !a;
             }
         },
-        stage: {
-            stageWidth: function(){
-                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'stageWidth']);
-                return Event.stage.width;
-            },
-            stageHeight: function(){
-                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'stageHeight']);
-                return Event.stage.height;
-            },
-            centerX: function(){
-                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'centerX']);
-                return (Event.stage.width / 2);
-            },
-            centerY: function(){
-                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'centerY']);
-                return (Event.stage.height / 2);
-            },
-            randomX: function(){
-                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'randomX']);
-                return Math.random() * Event.stage.width;
-            },
-            randomY: function(){
-                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'randomY']);
-                return Math.random() * Event.stage.height;
-            },
-        },
         color: {
             namedColor: function(name){
                 // FIXME: We may need to return hex or other color value
@@ -971,7 +945,42 @@
                 spt.stayWithinRect(canvasRect());
             }
         },
-
+        stage: {
+            clearTo: new util.Method()
+                .when(['string'], function(clr){ // unfortunately colors are still strings
+                    var r = canvasRect();
+                    ctx().fillStyle = clr;
+                    ctx().fillRect(r.x, r.y, r.width, r.height);
+                })
+                .when(['wbimage'], function(img){
+                    img.drawInRect(ctx(), canvasRect());
+                })
+            .fn(),
+            stageWidth: function(){
+                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'stageWidth']);
+                return Event.stage.width;
+            },
+            stageHeight: function(){
+                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'stageHeight']);
+                return Event.stage.height;
+            },
+            centerX: function(){
+                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'centerX']);
+                return (Event.stage.width / 2);
+            },
+            centerY: function(){
+                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'centerY']);
+                return (Event.stage.height / 2);
+            },
+            randomX: function(){
+                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'randomX']);
+                return Math.random() * Event.stage.width;
+            },
+            randomY: function(){
+                _gaq.push(['_trackEvent', 'Blocks', 'Stage', 'randomY']);
+                return Math.random() * Event.stage.height;
+            },
+        },
         string: {
 
             toString: function(x){

--- a/js/util.js
+++ b/js/util.js
@@ -819,33 +819,37 @@
 
     WBImage.prototype.draw = function(ctx){
         ctx.drawImage(this._image, -this.width/2, -this.height/2, this.width, this.height);
-    }
+    };
 
     WBImage.prototype.drawAtPoint = function(ctx, pt){
         ctx.translate(pt.x, pt.y);
         this.draw(ctx);
         ctx.setTransform(1,0,0,1,0,0); // back to identity matrix
-    }
+    };
+
+    WBImage.prototype.drawInRect = function(ctx, r){
+        ctx.drawImage(this._image, r.x, r.y, r.width, r.height);
+    };
 
     WBImage.prototype.setWidth = function(w){
         this.width = w;
         this.height = this.width * this.origProportion;
-    }
+    };
 
     WBImage.prototype.setHeight = function(h){
         this.height = h;
         this.width = this.height / this.origProportion;
-    }
+    };
 
     WBImage.prototype.setSize = function(sz){
         this.width = sz.w;
         this.height = sz.h;
-    }
+    };
 
     WBImage.prototype.scale = function(scaleFactor){
         this.width = this.origWidth * scaleFactor;
         this.height = this.origHeight * scaleFactor;
-    }
+    };
 
 
     /******************************

--- a/playground.html
+++ b/playground.html
@@ -372,6 +372,9 @@
                     <img class="cat-icon" src="images/icon/stage.svg" />
                     Stage
                 </header>
+                <wb-step script="stage.clearTo">
+                    <wb-value type="color,image">clear to</wb-value>
+                </wb-step>
 				<wb-expression type="number" script="stage.stageWidth">
 					<wb-value>Stage Width</wb-value>
 				</wb-expression>


### PR DESCRIPTION
There is a strange behaviour (maybe a bug) in the image pre-loader that causes the image to load after the sprite in the demo if the `image from [url]` block is placed directly in the `clear to [image]` block. If the image is saved to a variable, and the variable is used, this is not a problem. Will file that seperately, but wanted to note it for testing. There are test scripts for clearing to both color and image in a comment for #970.