### PR TITLE
Fix missing functions

### DIFF
--- a/js/runtime.js
+++ b/js/runtime.js
@@ -131,6 +131,20 @@
             //temporary fix for locals
             value: function(){
                 return this.value;
+            },
+            index: function () {
+                console.assert(false, 'Not implemented');
+                // FIXME: loopover cannot handle locals for nested loops!
+                return this.index;
+            },
+            key: function () {
+                console.assert(false, 'Not implemented');
+                // FIXME: loopover cannot handle locals for nested loops!
+                return this.key;
+            },
+            data: function () {
+                console.assert(false, 'Not implemented');
+                // FIXME: how do we get the name of the local?
             }
         },
 

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -131,20 +131,6 @@
             //temporary fix for locals
             value: function(){
                 return this.value;
-            },
-            index: function () {
-                console.assert(false, 'Not implemented');
-                // FIXME: loopover cannot handle locals for nested loops!
-                return this.index;
-            },
-            key: function () {
-                console.assert(false, 'Not implemented');
-                // FIXME: loopover cannot handle locals for nested loops!
-                return this.key;
-            },
-            data: function () {
-                console.assert(false, 'Not implemented');
-                // FIXME: how do we get the name of the local?
             }
         },
 

--- a/playground.html
+++ b/playground.html
@@ -595,7 +595,7 @@
                     <wb-value type="number" value="0">vector at x</wb-value>
                     <wb-value type="number" value="0">y</wb-value>
                 </wb-expression>
-                <wb-expression type="vector" script="vector.createPolar">
+                <wb-expression type="vector" script="vector.fromPolar">
                     <wb-value type="number" value="0">vector at angle</wb-value>
                     <wb-value type="number" value="0">magnitude</wb-value>
                 </wb-expression>

--- a/playground.html
+++ b/playground.html
@@ -595,7 +595,7 @@
                     <wb-value type="number" value="0">vector at x</wb-value>
                     <wb-value type="number" value="0">y</wb-value>
                 </wb-expression>
-                <wb-expression type="vector" script="vector.fromPolar">
+                <wb-expression type="vector" script="vector.createPolar">
                     <wb-value type="number" value="0">vector at angle</wb-value>
                     <wb-value type="number" value="0">magnitude</wb-value>
                 </wb-expression>


### PR DESCRIPTION
This fixes the missing functions reported by the PhantomJS script created in #1011 so that future pushes don't accidentally break the build.

~~Note that the functions defined for the locals in  `control.loopOver` and `control.receive` are stubs. It seems that their actual implementation would require considerable effort for both.~~

**LOL DISREGARD THAT** I just merged in Dethe's fixes because we happened to be working on the same thing at the same time.