### PR TITLE
Added package.json for keeping all the tests together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-before_script:
-  - npm install
-script:
-  - ./run_tests.sh
+# The following are the default, but explicit is better.
+install: npm install
+script: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 before_script:
-  - npm install -g node-qunit-phantomjs
-script: ./tests.sh
+  - npm install
+script:
+  - ./run_tests.sh

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "waterbear",
+  "version": "0.2.0",
+  "description": "Visual programming language for non-programmers.",
+  "private": true,
+  "directories": {
+    "doc": "docs",
+    "example": "example",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "./run_tests.sh"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/waterbearlang/waterbear.git"
+  },
+  "author": "Dethe Elza <dethe@livingcode.org>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/waterbearlang/waterbear/issues"
+  },
+  "homepage": "https//waterbearlang.com/",
+  "devDependencies": {
+    "node-qunit-phantomjs": "^1.2.0"
+  }
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Runs all the tests on this project. On OS X with Homebrew (you can probably
+# use `apt-get` instead of `brew` on Ubuntu):
+#
+#   $ brew install node phantomjs
+#   $ npm install
+#
+# NOTE: npm (& node) is ONLY required for testing (for now...).
+
+set -e # Exit on first error.
+set -x # Print every command.
+
+node-qunit-phantomjs test/runtime.html
+phantomjs test/all-blocks-have-functions.js playground.html

--- a/tests.sh
+++ b/tests.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-node-qunit-phantomjs test/runtime.html && phantomjs test/all-blocks-have-functions.js playground.html


### PR DESCRIPTION
Originally meant as a piece of #1017, but this is the part that actually works. **EITHER MERGE THIS OR #1017!**

Basically, if you have Node/NPM, you too can test Waterbear by doing `npm install && npm test`!