### PR TITLE
fix editing variable names in Firefox (issue #1021)

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -53,7 +53,7 @@ function setDefaultByTag(element, tagname, top){
 // Make sure these elements are always inserted into a header element
 // and that the header element exists
 function insertIntoHeader(){
-    var parent = this.parentElement.tagName.toLowerCase();
+    var parent = this.parentElement.localName;
     if (parent === 'header' || parent === 'wb-row') return;
     var block = dom.closest(this, 'wb-step, wb-context, wb-expression');
     var head = setDefaultByTag(block, 'header');
@@ -72,7 +72,7 @@ var BlockProto = Object.create(HTMLElement.prototype);
 BlockProto.createdCallback = function blockCreated(){
     // Add required structure
     setDefaultByTag(this, 'header', true);
-    // console.log('%s created with %s children', this.tagName.toLowerCase(), this.children.length);
+    // console.log('%s created with %s children', this.localName, this.children.length);
 };
 BlockProto.attachedCallback = function blockAttached(){
     // Add locals
@@ -91,11 +91,11 @@ BlockProto.attachedCallback = function blockAttached(){
     }else{
         // console.warn('free-floating block: %o, OK for now', this);
     }
-    // console.log('%s attached', this.tagName.toLowerCase());
+    // console.log('%s attached', this.localName);
 };
 BlockProto.detachedCallback = function blockDetached(){
     // Remove locals
-    // console.log('%s detached', this.tagName.toLowerCase());
+    // console.log('%s detached', this.localName);
 };
 BlockProto.attributeChangedCallback = function(attrName, oldVal, newVal){
     // Attributes to watch for:
@@ -103,7 +103,7 @@ BlockProto.attributeChangedCallback = function(attrName, oldVal, newVal){
     //    title or help (do nothing)
     //    script (do nothing)
     //    type (do nothing
-    // console.log('%s[%s] %s -> %s', this.tagName.toLowerCase(), attrName, oldVal, newVal);
+    // console.log('%s[%s] %s -> %s', this.localName, attrName, oldVal, newVal);
 };
 BlockProto.gatherValues = function(scope){
     if (!this.values){
@@ -145,7 +145,7 @@ function handleVariableFocus(evt){
     // Gather all the locals so we can update them
     // TODO: Cancel if the new variable name is already in scope
     var input = evt.target;
-    if (!input.parentElement.hasAttribute('isVariable')){
+    if (!input.parentElement.hasAttribute('isvariable')){
         return
     }
     var parentContext = dom.closest(input, 'wb-contains');
@@ -160,7 +160,7 @@ function handleVariableFocus(evt){
 function handleVariableInput(evt){
     // Actually change the locals while we update
     var input = evt.target;
-    if (!input.parentElement.hasAttribute('isVariable')){
+    if (!input.parentElement.hasAttribute('isvariable')){
         return;
     }
     var newVariableName = input.value;
@@ -175,18 +175,18 @@ function handleVariableInput(evt){
 function handleVariableBlur(evt){
     // Cleanup
     var input = evt.target;
-    if (!input.parentElement.hasAttribute('isVariable')){
+    if (!input.parentElement.hasAttribute('isvariable')){
         return;
     }
     variableLocalsToUpdate = null;
     oldVariableName = '';
 }
 
-Event.on(document.body, 'editor:focus', '[isVariable] input', handleVariableFocus); // Mozilla
-Event.on(document.body, 'editor:focusin', '[isVariable] input', handleVariableFocus); // All other browsers
-Event.on(document.body, 'editor:input', '[isVariable] input', handleVariableInput);
-Event.on(document.body, 'editor:blur',  '[isVariable] input', handleVariableBlur); // Mozilla
-Event.on(document.body, 'editor:focusout',  '[isVariable] input', handleVariableBlur); // All other browsers
+Event.on(document.body, 'editor:focus', '[isvariable] input', handleVariableFocus); // Mozilla
+Event.on(document.body, 'editor:focusin', '[isvariable] input', handleVariableFocus); // All other browsers
+Event.on(document.body, 'editor:input', '[isvariable] input', handleVariableInput);
+Event.on(document.body, 'editor:blur',  '[isvariable] input', handleVariableBlur); // Mozilla
+Event.on(document.body, 'editor:focusout',  '[isvariable] input', handleVariableBlur); // All other browsers
 
 // Context Proto
 // Instantiated as new WBContext or as <wb-context>
@@ -234,7 +234,7 @@ ContextProto.run = function(parentScope){
 ContextProto.showLocals = function(evt){
     // This is way too specific to the needs to the loopOver block
     var blockAdded = evt.detail;
-    if (blockAdded && blockAdded.tagName.toLowerCase() === 'wb-expression'){
+    if (blockAdded && blockAdded.localName === 'wb-expression'){
         var type = blockAdded.getAttribute('type');
         var header = dom.child(this, 'header');
         if (!header){
@@ -256,7 +256,7 @@ ContextProto.showLocals = function(evt){
 ContextProto.hideLocals = function(evt){
     // This is way too specific to the needs to the loopOver block
     var blockAdded = evt.detail;
-    if (blockAdded && blockAdded.tagName.toLowerCase() === 'wb-expression'){
+    if (blockAdded && blockAdded.localName === 'wb-expression'){
         var header = dom.child(this, 'header');
         if (!header) return;
         var row = dom.child(header, 'wb-row');
@@ -321,7 +321,7 @@ ExpressionProto.attachedCallback = function expressionAttached(){
             sib.classList.add('hide');
         });
     }
-    if (this.parent.tagName.toLowerCase() !== 'wb-local'){
+    if (this.parent.localName !== 'wb-local'){
         var blockParent = dom.closest(this.parent, 'wb-expression, wb-step, wb-context');
         if (blockParent){
             Event.trigger(blockParent, 'wb-added', this);
@@ -337,7 +337,7 @@ ExpressionProto.detachedCallback = function expressionDetached(){
             sib.classList.remove('hide');
         });
     }
-    if (this.parent.tagName.toLowerCase() !== 'wb-local'){
+    if (this.parent.localName !== 'wb-local'){
         var blockParent = dom.closest(this.parent, 'wb-expression, wb-step, wb-context');
         if (blockParent){
             Event.trigger(blockParent, 'wb-removed', this);
@@ -420,7 +420,7 @@ window.WBDisclosure = document.registerElement('wb-disclosure', {prototype: Disc
 function toggleClosed(evt){
     console.log('toggle');
     var block = dom.closest(evt.target, 'wb-step, wb-context, wb-expression');
-    console.log('%s closed = %s', block.tagName.toLowerCase(), block.getAttribute('closed'));
+    console.log('%s closed = %s', block.localName, block.getAttribute('closed'));
     if (block.hasAttribute('closed')){
         block.removeAttribute('closed');
     }else{
@@ -637,7 +637,7 @@ Event.on(document.body, 'editor:drag-start', 'wb-step, wb-step *, wb-context, wb
     dragStart = dom.matches(origTarget, 'wb-contains *') ? 'script' : 'menu';
     // Warning here: origTarget may be null, and thus, not have a
     // parentElement.
-    if (origTarget.parentElement.nodeName.toLowerCase() === 'wb-local'){
+    if (origTarget.parentElement.localName === 'wb-local'){
         dragStart = 'menu';
     }
     if (dragStart === 'script'){

--- a/js/event.js
+++ b/js/event.js
@@ -114,7 +114,12 @@
                 handler(evt);
             }
         };
-        elem.addEventListener(eventname, listener, false);
+        /// liveFix is needed because Firefox doesn't support "focusin" events and "focus" events don't bubble
+        var liveFix = false;
+        if (selector && (eventname === 'focus' || eventname === 'blur')){ // any others?
+            liveFix = true;
+        }
+        elem.addEventListener(eventname, listener, liveFix);
         util.setDefault(allEvents, namespace, []).push(new ScopedEvent(elem, eventname, listener));
         return listener;
     }

--- a/playground.html
+++ b/playground.html
@@ -60,7 +60,7 @@
                 </wb-context>
                 <wb-step script="control.setVariable" class="control">
                     <wb-row>
-                    <wb-value type="text" isVariable="true" allow="literal" value="variable">set</wb-value>
+                    <wb-value type="text" isvariable="true" allow="literal" value="variable">set</wb-value>
                         <wb-local>
                             <wb-expression type="any" script="control.getVariable">
                                 <wb-value value="variable">variable</wb-value>
@@ -126,7 +126,7 @@
                 <wb-step script="control.ask" class="control">
                     <wb-row>
                         <wb-value type="text,string">Ask</wb-value>
-                        <wb-value type="text" isVariable="true" allow="literal" value="variable">and store in variable</wb-value>
+                        <wb-value type="text" isvariable="true" allow="literal" value="variable">and store in variable</wb-value>
                         <wb-local>
                             <wb-expression type="any" script="control.getVariable">
                                 <wb-value value="variable">variable</wb-value>

--- a/test/all-blocks-have-functions.js
+++ b/test/all-blocks-have-functions.js
@@ -27,7 +27,7 @@ page.open(pageName, function (status) {
         var selector = 'sidebar wb-context, sidebar wb-expression, sidebar wb-step';
         var allBlocks = document.querySelectorAll(selector);
         var badScripts = [];
-    
+
         /* Check the script for each block. */
         Array.prototype.forEach.call(allBlocks, function (block) {
             var scriptAttr = block.attributes.script;
@@ -69,7 +69,7 @@ page.open(pageName, function (status) {
 
         function addBadScript(block, reason) {
             badScripts.push({
-                'element': block.tagName.toLowerCase(),
+                'element': block.localName,
                 'script': block.attributes.script ?
                     block.attributes.script.value :
                     '<unknown>',

--- a/test/qunit-git.js
+++ b/test/qunit-git.js
@@ -1848,7 +1848,7 @@ QUnit.dump = (function() {
 					var len, i, val,
 						open = dump.HTML ? "&lt;" : "<",
 						close = dump.HTML ? "&gt;" : ">",
-						tag = node.nodeName.toLowerCase(),
+						tag = node.localName,
 						ret = open + tag,
 						attrs = node.attributes;
 

--- a/test/qunit-git.js
+++ b/test/qunit-git.js
@@ -1848,7 +1848,7 @@ QUnit.dump = (function() {
 					var len, i, val,
 						open = dump.HTML ? "&lt;" : "<",
 						close = dump.HTML ? "&gt;" : ">",
-						tag = node.localName,
+						tag = node.nodeName.toLowerCase(),
 						ret = open + tag,
 						attrs = node.attributes;
 

--- a/test/sinon-1.12.2.js
+++ b/test/sinon-1.12.2.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -461,7 +461,7 @@
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true,
@@ -564,7 +564,7 @@
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -584,7 +584,7 @@
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -618,12 +618,12 @@
     };
 
     ascii.element = function (element) {
-        var tagName = element.tagName.toLowerCase();
+        var tagName = element.localName;
         var attrs = element.attributes, attr, pairs = [], attrName, i, l, val;
 
         for (i = 0, l = attrs.length; i < l; ++i) {
             attr = attrs.item(i);
-            attrName = attr.nodeName.toLowerCase().replace("html:", "");
+            attrName = attr.localName.replace("html:", "");
             val = attr.nodeValue;
             if (attrName !== "contenteditable" || val !== "inherit") {
                 if (!!val) { pairs.push(attrName + "=\"" + val + "\""); }

--- a/test/sinon-1.12.2.js
+++ b/test/sinon-1.12.2.js
@@ -618,12 +618,12 @@
     };
 
     ascii.element = function (element) {
-        var tagName = element.localName;
+        var tagName = element.tagName.toLowerCase();
         var attrs = element.attributes, attr, pairs = [], attrName, i, l, val;
 
         for (i = 0, l = attrs.length; i < l; ++i) {
             attr = attrs.item(i);
-            attrName = attr.localName.replace("html:", "");
+            attrName = attr.nodeName.toLowerCase().replace("html:", "");
             val = attr.nodeValue;
             if (attrName !== "contenteditable" || val !== "inherit") {
                 if (!!val) { pairs.push(attrName + "=\"" + val + "\""); }


### PR DESCRIPTION
A few problems that were weird. Firefox was converting all attribute names to lowercase, which is behaviour I don't recall ever seeing before, and broke our use of `isVariable`. It also doesn't support the `focusin` event, which we'd already worked around, but the workaround had disappeared and had to be reimplemented. Not sure what happened there.