### PR TITLE
prevent selecting while dragging

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -144,3 +144,13 @@ wb-accordion.shape > header:after{ background-color: hsl(84, 93%, 56%); }
 wb-accordion.geolocation > header:after{ background-color: hsl(240, 93%, 56%); }
 wb-accordion.size > header:after{ background-color: hsl(192, 93%, 56%); }
 wb-accordion.text > header:after{ background-color: hsl(348, 93%, 56%); }
+
+/* Prevent selecting text while dragging */
+.dragging *{
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}

--- a/js/block.js
+++ b/js/block.js
@@ -650,7 +650,8 @@ Event.on(document.body, 'editor:drag-start', 'wb-step, wb-step *, wb-context, wb
 
 Event.on(document.body, 'editor:dragging', null, function(evt){
     if (!dragTarget){ return; }
-
+    evt.preventDefault();
+    evt.stopPropagation();
     // FIXME: hardcoded margin (???) values.
     // Essentially, the block is always dragged at an area 15 px away from the
     // top-left corner.

--- a/js/event.js
+++ b/js/event.js
@@ -249,6 +249,7 @@
         dragTarget = null;
         isDragging = false;
         Event.pointerDown = false;
+        document.body.classList.remove('dragging');
         trigger(document, 'drag-reset');
     }
 
@@ -258,6 +259,8 @@
         if (dom.closest(evt.target, 'input, select')){
             return undefined;
         }
+        // prevent text selection while dragging
+        document.body.classList.add('dragging');
         Event.pointerDown = true;
         Event.pointerX = evt.pageX;
         Event.pointerY = evt.pageY;
@@ -291,6 +294,7 @@
             }
         }
         evt.preventDefault();
+        evt.stopPropagation();
         forward(dragTarget, 'dragging', evt);
         return false;
     }


### PR DESCRIPTION
This should fix the problem of highlighting text while dragging blocks. You can still drag to highlight within text inputs.