### PR TITLE
added basic help

### DIFF
--- a/playground.html
+++ b/playground.html
@@ -44,6 +44,7 @@
                     <img class="cat-icon" src="images/icon/control.svg" />
                     Controls
                 </header>
+                <p>Contains flow control, messaging, looping, variables, and conditionals.</p>
                 <wb-context script="control.whenProgramRuns" class="control">
                     <wb-value>when program runs</wb-value>
                 </wb-context>
@@ -153,6 +154,7 @@
                     <img class="cat-icon" src="images/icon/sprite.svg" />
                     Sprites
                 </header>
+                <p>Sprites are images or shapes that can have momentum and heading direction applied to them for animation and games.</p>
                 <wb-expression type="sprite" script="sprite.create" />
                     <wb-value type="wb-image,shape,sprite">sprite with</wb-value>
                 </wb-expression>
@@ -218,6 +220,7 @@
                     <img class="cat-icon" src="images/icon/sound.svg" />
                     Sound
                 </header>
+                <p>Play and manipulate existing sound files or synthesize new sounds.</p>
                 <wb-expression type="sound" isAsset="true" script="sound.get">
                     <wb-value type="text" value="test/monster.wav">sound from url</wb-value>
                 </wb-expression>
@@ -323,6 +326,7 @@
                     <img class="cat-icon" src="images/icon/array.svg" />
                     Arrays
                 </header>
+                <p>Arrays are lists of things. You can add, remove, and loop over these lists.</p>
                 <wb-expression type="array" script="array.create">
                     <wb-value>create array</wb-value>
                     <wb-row>
@@ -372,6 +376,7 @@
                     <img class="cat-icon" src="images/icon/boolean.svg" />
                     Boolean
                 </header>
+                <p>Booleans are either True or False. There are many operations for comparing and mixing them.</p>
                 <wb-expression type="boolean" script="boolean.and">
                     <wb-value type="boolean" value="true"></wb-value>
                     <wb-value type="boolean" value="true">and</wb-value>
@@ -393,6 +398,7 @@
                     <img class="cat-icon" src="images/icon/stage.svg" />
                     Stage
                 </header>
+                <p>Stage is the area where scripts are performed.</p>
                 <wb-step script="stage.clearTo">
                     <wb-value type="color,wb-image">clear to</wb-value>
                 </wb-step>
@@ -420,6 +426,7 @@
                     <img class="cat-icon" src="images/icon/color.svg" />
                     Colors
                 </header>
+                <p>There are several ways to specify colors.</p>
                 <wb-expression type="color" script="color.namedColor">
                     <wb-value type="list" allow="literal" options="black,white,navy,blue,aqua,teal,olive,green,lime,yellow,orange,red,fuchsia,rebeccapurple,maroon,grey,silver,transparent" value="black"></wb-value>
                 </wb-expression>
@@ -463,6 +470,7 @@
                     <img class="cat-icon" src="images/icon/image.svg" />
                     Images
                 </header>
+                <p>Images are pictures loaded from the web. They can be positioned and resized.</p>
                 <wb-expression type="wb-image" isAsset="true" script="image.get" class="image">
                     <wb-value type="text" value="images/mascot/mascot-steampunk.png">image from url</wb-value>
                 </wb-expression>
@@ -498,6 +506,7 @@
                     <img class="cat-icon" src="images/icon/math.svg" />
                     Math
                 </header>
+                <p>In addition to performing math on numbers you can also use many operations on arrays and vectors too.</p>
                 <wb-expression script="math.add" type="number">
                     <wb-value type="number,vector,array" value="0"></wb-value>
                     <wb-value type="number,vector,array" value="0">+</wb-value>
@@ -601,6 +610,7 @@
                     <img class="cat-icon" src="images/icon/random.svg" />
                     Random
                 </header>
+                <p>There are many types of randomness in Waterbear.</p>
                 <wb-expression type="number" script="random.randFloat">
                     <wb-value>random float</wb-value>
                 </wb-expression>
@@ -622,6 +632,7 @@
                     <img class="cat-icon" src="images/icon/vector.svg" />
                     Vectors
                 </header>
+                <p>Waterbear vectors are 2-D objects expressing x and y coordinates, but also a direction and magnitude (useful for speed, acceleration, distance).</p>
                 <wb-expression type="vector" script="vector.create">
                     <wb-value type="number" value="0">vector at x</wb-value>
                     <wb-value type="number" value="0">y</wb-value>
@@ -668,6 +679,7 @@
                     <img class="cat-icon" src="images/icon/object.svg" />
                     Objects
                 </header>
+                <p>Objects are general-purpose containers where you can associate names (keys) with objects (values) like in a dictionary.</p>
                 <wb-expression type="object" script="object.empty">
                     empty object
                 </wb-expression>
@@ -692,6 +704,7 @@
                     <img class="cat-icon" src="images/icon/string.svg" />
                     Strings
                 </header>
+                <p>Strings are simple bits of text. You can search them, combine them, and break them up.</p>
                 <wb-expression script="string.toString" type="string">
                     <wb-value type="any">convert</wb-value>to string
                 </wb-expression>
@@ -769,6 +782,7 @@
                     <img class="cat-icon" src="images/icon/point.svg" />
                     Points
                 </header>
+                <p>Points are x,y coordinates like vectors but without magnitude and direction.</p>
                 <wb-expression type="point" script="point.create">
                     <wb-value type="number" value="0">x</wb-value>
                     <wb-value type="number" value="0">y</wb-value>
@@ -797,6 +811,7 @@
                     <img class="cat-icon" src="images/icon/path.svg" />
                     Paths
                 </header>
+                <p>Paths are drawing instructions for producing an image from a series of points.</p>
                 <wb-step script = "path.lineStyle" type="path">
                     <wb-value type="number">line width</wb-value>
                     <wb-value type="color" value="#0000FF">line color</wb-value>
@@ -842,6 +857,7 @@
                     <img class="cat-icon" src="images/icon/shape.svg" />
                     Shapes
                 </header>
+                <p>Shapes are simple pictures made by drawing a geometric shape rather than loading an image file.</p>
                  <wb-step script=shape.fill class="shape">
                     <wb-value type="shape">fill the shape</wb-value>
                 </wb-step>
@@ -870,6 +886,7 @@
                     <img class="cat-icon" src="images/icon/rect.svg" />
                     Rects
                 </header>
+                <p>It turns out to be frequently useful to be able to represent a rectangle.</p>
                 <wb-expression type="rect" script="rect.fromCoordinates" class="rect">
                     <wb-value type="number" value="0">x</wb-value>
                     <wb-value type="number" value="0">y</wb-value>
@@ -907,6 +924,7 @@
                     <img class="cat-icon" src="images/icon/sense.svg" />
                     Input
                 </header>
+                <p>Programs can get input from the mouse, touch, key presses, and more.</p>
                 <wb-expression type="number" script="input.mouseX">
                     <wb-value>Mouse x</wb-value>
                 </wb-expression>
@@ -933,11 +951,10 @@
                         <img class="cat-icon" src="images/icon/geolocation.svg" />
                         Geolocation
                     </header>
-
+                    <p>Where in the world is your progam running?</p>
                     <wb-expression type="geolocation" script="geolocation.currentLocation">
                         my current location
                     </wb-expression>
-
                     <wb-context script="geolocation.whenLocationUpdated" class="geolocation">
                         <wb-row>
                             <wb-value>when my location changes</wb-value>
@@ -948,7 +965,6 @@
                             </wb-local>
                         </wb-row>
                     </wb-context>
-
                     <wb-expression type="number" script="geolocation.latitude">
                         <wb-value type="geolocation" allow="expression">latitude of</wb-value>
                     </wb-expression>
@@ -970,6 +986,7 @@
                         <img class="cat-icon" src="images/icon/size.svg" />
                         Sizes
                     </header>
+                    <p>A size captures both width and height in one convenient package.</p>
                     <wb-expression type="size" script="size.fromCoordinates">
                         <wb-value type="number" value="0">size from width</wb-value>
                         <wb-value type="text" value="px">width units</wb-value>
@@ -998,6 +1015,7 @@
                         <img class="cat-icon" src="images/icon/text.svg" />
                         Text
                     </header>
+                    <p>Text is like a string, but formatted for printing to the screen.</p>
                     <wb-step script="text.setFont" class="text">
                         <wb-row>
                             <wb-value type = "number" value = "12">font</wb-value>
@@ -1090,7 +1108,7 @@
                             <button class="do-stop" onclick="_gaq.push(['_trackEvent', 'Action', 'stop']);">Stop</button>
                         </wb-hbox>
                         <div class = "canvas-holder">
-                            
+
                         </div>
                     </div>
                 </wb-hbox>
@@ -1112,7 +1130,7 @@
                             <img src="images/png/steampunk.png">
                         </div>
                         <div class="congrats">
-                            Congratulations! Move on to the next step! 
+                            Congratulations! Move on to the next step!
                             <button class="nextTutorial">Next Step</button>
                         </div>
                     </div>


### PR DESCRIPTION
I'm happy to have input for improving the help strings, but wanted to get something basic in to start from. The beauty of building Waterbear with custom elements is that it is very easy to mix in regular old HTML. All I did was add `<p>` tags with the help text to each menu section. Inside the `<p>` we could have formatted text, links, whatever.

We can style the help text too. Any suggestions for improved styling are welcome.