### PR TITLE
Remove Google Analytics onclick handlers.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -110,6 +110,7 @@ Event.on('.do-step', 'ui:click', null, function () {
 });
 
 function startScript(evt){
+    _gaq.push(['_trackEvent', 'Actions', 'run']);
     // Do any necessary cleanup (e.g., clear event handlers).
     stopScript(evt);
     runtime.resetStage();
@@ -119,6 +120,7 @@ function startScript(evt){
 }
 
 function stopScript(evt) {
+    _gaq.push(['_trackEvent', 'Action', 'stop']);
     if (process) {
         process.terminate();
         /* Throw out the now-useless process. */
@@ -153,6 +155,7 @@ function runScript(){
 }
 
 function handleFileButton(evt){
+    _gaq.push(['_trackEvent', 'File', 'file']);
     var fileModel = nanoModal("Select an option or click away to exit.",
         {overlayClose: true, // Can't close the modal by clicking on the overlay.
         buttons: [{
@@ -201,6 +204,7 @@ function handleFileButton(evt){
 Event.on(document.body, 'ui:click', '.open-files', handleFileButton);
 
 function handleExampleButton(evt){
+    _gaq.push(['_trackEvent', 'Tutorial', 'examples']);
     var fileModel = nanoModal("Load an example program.",
         {overlayClose: true, // Can't close the modal by clicking on the overlay.
         buttons: [{
@@ -225,6 +229,7 @@ function handleExampleButton(evt){
 }
 
 function handleTutorialButton(evt){
+    _gaq.push(['_trackEvent', 'Tutorial', 'tutorials']);
     var fileModel = nanoModal("Load a tutorial.",
         {overlayClose: true, // Can't close the modal by clicking on the overlay.
         buttons: [{

--- a/js/app_play.js
+++ b/js/app_play.js
@@ -32,6 +32,7 @@ Event.on('.do-run', 'ui:click', null, startScript);
 Event.on('.do-stop', 'ui:click', null, stopScript);
 
 function startScript(evt){
+    _gaq.push(['_trackEvent', 'Actions', 'run']);
     // Do any necessary cleanup (e.g., clear event handlers).
     stopScript(evt);
     runtime.resetStage();
@@ -43,6 +44,7 @@ function startScript(evt){
 }
 
 function stopScript(evt) {
+    _gaq.push(['_trackEvent', 'Action', 'stop']);
     if (process) {
         process.terminate();
         /* Throw out the now-useless process. */

--- a/js/event.js
+++ b/js/event.js
@@ -532,11 +532,13 @@
 
     function handleUndoButton(evt) {
         evt.preventDefault();
+        _gaq.push(['_trackEvent', 'Undo', 'undo']);
         undoEvent();
     }
 
     function handleRedoButton(evt) {
         evt.preventDefault();
+        _gaq.push(['_trackEvent', 'Redo', 'redo']);
         redoEvent();
     }
 

--- a/play.html
+++ b/play.html
@@ -36,8 +36,8 @@
     <wb-playground>
         <div class="menu">
             <a class="do-breakout" target="_blank" href="playground.html">Open in Workshop</a>
-            <button class="do-run" onclick="_gaq.push(['_trackEvent', 'Actions', 'run']);">Run</button>
-            <button class="do-stop" onclick="_gaq.push(['_trackEvent', 'Action', 'stop']);">Stop</button>
+            <button class="do-run">Run</button>
+            <button class="do-stop">Stop</button>
         </div>
         <canvas></canvas>
     </wb-playground>

--- a/playground.html
+++ b/playground.html
@@ -32,11 +32,11 @@
         <wb-vbox>
 
         <div class="menu">
-            <button class="open-files" onclick="_gaq.push(['_trackEvent', 'File', 'file']);">File</button>
-            <button class="undo" id="undoButton" title="Ctrl-Z or ⌘-Z" onclick="_gaq.push(['_trackEvent', 'Undo', 'undo']);">Undo</button>
-            <button class="redo" id="redoButton" title="Ctrl-Y or ⌘-Shift-Z" onclick="_gaq.push(['_trackEvent', 'Redo', 'redo']);">Redo</button>
-            <button class="open-example" onclick="_gaq.push(['_trackEvent', 'Tutorial', 'examples']);">Examples</button>
-            <button class="open-tutorial" onclick="_gaq.push(['_trackEvent', 'Tutorial', 'tutorials']);">Tutorials</button>
+            <button class="open-files">File</button>
+            <button class="undo" id="undoButton" title="Ctrl-Z or ⌘-Z">Undo</button>
+            <button class="redo" id="redoButton" title="Ctrl-Y or ⌘-Shift-Z">Redo</button>
+            <button class="open-example">Examples</button>
+            <button class="open-tutorial">Tutorials</button>
         </div>
         <wb-workbox>
         <sidebar>
@@ -1084,8 +1084,8 @@
         <wb-displaybox class="canvas" selected='true'>
             <wb-playground>
                 <div class="menu">
-                    <button class="do-run" onclick="_gaq.push(['_trackEvent', 'Actions', 'run']);">Run</button>
-                    <button class="do-stop" onclick="_gaq.push(['_trackEvent', 'Action', 'stop']);">Stop</button>
+                    <button class="do-run">Run</button>
+                    <button class="do-stop">Stop</button>
                 </div>
                 <canvas></canvas>
             </wb-playground>

--- a/tutorial/wb-piano.html
+++ b/tutorial/wb-piano.html
@@ -62,8 +62,8 @@ Make sure do draw the shapes in order: The back of the piano has to be drawn bef
         <div>
             <wb-hbox>
                 <h6> Actual output:</h6>
-                <button class="do-run" onclick="_gaq.push(['_trackEvent', 'Actions', 'run']);">Run</button>
-                <button class="do-stop" onclick="_gaq.push(['_trackEvent', 'Action', 'stop']);">Stop</button>
+                <button class="do-run">Run</button>
+                <button class="do-stop">Stop</button>
             </wb-hbox>
             <div class = "canvas-holder">
                 
@@ -286,8 +286,8 @@ Did you remember to change the letter int he drop down menu for each "when key p
         <div>
             <wb-hbox>
                 <h6> Actual output:</h6>
-                <button class="do-run" onclick="_gaq.push(['_trackEvent', 'Actions', 'run']);">Run</button>
-                <button class="do-stop" onclick="_gaq.push(['_trackEvent', 'Action', 'stop']);">Stop</button>
+                <button class="do-run">Run</button>
+                <button class="do-stop">Stop</button>
             </wb-hbox>
             <div class = "canvas-holder">
                 
@@ -575,8 +575,8 @@ Strategy Hints:<br /> Did you redraw the text as well as the rectangle for the k
         <div>
             <wb-hbox>
                 <h6> Actual output:</h6>
-                <button class="do-run" onclick="_gaq.push(['_trackEvent', 'Actions', 'run']);">Run</button>
-                <button class="do-stop" onclick="_gaq.push(['_trackEvent', 'Action', 'stop']);">Stop</button>
+                <button class="do-run">Run</button>
+                <button class="do-stop">Stop</button>
             </wb-hbox>
             <div class = "canvas-holder">
                 

--- a/tutorial/wb_in_space.html
+++ b/tutorial/wb_in_space.html
@@ -40,8 +40,8 @@ Can you only see part of an image? That’s fine! We’ll move it later.
         <div>
             <wb-hbox>
                 <h6> Actual output:</h6>
-                <button class="do-run" onclick="_gaq.push(['_trackEvent', 'Actions', 'run']);">Run</button>
-                <button class="do-stop" onclick="_gaq.push(['_trackEvent', 'Action', 'stop']);">Stop</button>
+                <button class="do-run">Run</button>
+                <button class="do-stop">Stop</button>
             </wb-hbox>
             <div class = "canvas-holder">
                 
@@ -164,8 +164,8 @@ Try positioning the rectangle at the origin (0,0).
         <div>
             <wb-hbox>
                 <h6> Actual output:</h6>
-                <button class="do-run" onclick="_gaq.push(['_trackEvent', 'Actions', 'run']);">Run</button>
-                <button class="do-stop" onclick="_gaq.push(['_trackEvent', 'Action', 'stop']);">Stop</button>
+                <button class="do-run">Run</button>
+                <button class="do-stop">Stop</button>
             </wb-hbox>
             <div class = "canvas-holder">
                 
@@ -295,8 +295,8 @@ Strategy Hints: Try setting the position using the “center x” and “center 
         <div>
             <wb-hbox>
                 <h6> Actual output:</h6>
-                <button class="do-run" onclick="_gaq.push(['_trackEvent', 'Actions', 'run']);">Run</button>
-                <button class="do-stop" onclick="_gaq.push(['_trackEvent', 'Action', 'stop']);">Stop</button>
+                <button class="do-run">Run</button>
+                <button class="do-stop">Stop</button>
             </wb-hbox>
             <div class = "canvas-holder">
                 
@@ -447,8 +447,8 @@ Strategy Hints: Think about a <a href="http://www.google.com/url?q=http%3A%2F%2F
         <div>
             <wb-hbox>
                 <h6> Actual output:</h6>
-                <button class="do-run" onclick="_gaq.push(['_trackEvent', 'Actions', 'run']);">Run</button>
-                <button class="do-stop" onclick="_gaq.push(['_trackEvent', 'Action', 'stop']);">Stop</button>
+                <button class="do-run">Run</button>
+                <button class="do-stop">Stop</button>
             </wb-hbox>
             <div class = "canvas-holder">
                 


### PR DESCRIPTION
This handles all of the Google events on the play and playground page. Fixes #1080.