### PR TITLE
fix scroll and move output

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -43,6 +43,12 @@ body > header > h1{
     line-height: 34px;
 }
 
+body > output{
+    flex: 0 0 24px;
+    background: #EFEDEA;
+    color: #111111;
+}
+
 .menu{
     flex: 0 0 34px;
     background-color: #666666;
@@ -182,6 +188,7 @@ sidebar.trashcan:after{
 wb-workspace > wb-contains{
     border: 2px inset #CCC;
     position: relative;
+    padding-bottom: 16px;
 }
 
 wb-contains:empty::before{

--- a/css/widget.css
+++ b/css/widget.css
@@ -73,7 +73,7 @@ wb-workspace{
     display: flex;
     flex-direction: column;
     flex: 2 1;
-    overflow-x: auto;
+    /*overflow-x: auto;*/
 }
 
 wb-workspace > header{
@@ -90,7 +90,7 @@ wb-workspace > wb-locals{
 
 wb-workspace > wb-contains{
     flex: 3 1;
-    overflow-y: auto;
+    overflow: auto;
 }
 
 @keyframes slidey-stripes {

--- a/css/widget.css
+++ b/css/widget.css
@@ -73,7 +73,6 @@ wb-workspace{
     display: flex;
     flex-direction: column;
     flex: 2 1;
-    /*overflow-x: auto;*/
 }
 
 wb-workspace > header{

--- a/js/block.js
+++ b/js/block.js
@@ -15,6 +15,7 @@
 'use strict';
     var elem = dom.html;
     var workspace = dom.find(document.body, 'wb-workspace');
+    var scriptspace = dom.find(document.body, 'wb-workspace > wb-contains');
     var selectedType = 'null';
     var BLOCK_MENU = document.querySelector('sidebar');
 
@@ -825,11 +826,34 @@ function startDragBlock(evt){
     }
     if (dragStart === 'script'){
         origTarget.classList.add('hide');
-        dom.child(origTarget.parentElement, 'input, select').classList.remove('hide');
+        var siblingInput = dom.child(origTarget.parentElement, 'input, select');
+        if (siblingInput){
+            siblingInput.classList.remove('hide');
+        }
     }
     dragTarget.classList.add('dragging');
     dragTarget.style.left = (evt.pageX - 15) + 'px';
     dragTarget.style.top = (evt.pageY - 15) + 'px';
+}
+
+
+function checkForScroll(evt){
+    requestAnimationFrame(checkForScroll);
+    if (!dragTarget){ return; }
+    var x = Event.pointerX;
+    var y = Event.pointerY;
+    var rect = scriptspace.getBoundingClientRect();
+    if (x < rect.left){
+        scriptspace.scrollLeft -= 5;
+    }else if (x > rect.right){
+        scriptspace.scrollLeft += 5;
+    }
+    if (y < rect.top){
+        scriptspace.scrollTop -= 5;
+    }else if (y > rect.bottom){
+        scriptspace.scrollTop += 5;
+    }
+    console.log('bottom: %s, scrollTop: %s, y: %s', rect.bottom, scriptspace.scrollTop, y);
 }
 
 function dragBlock(evt){
@@ -1087,6 +1111,9 @@ Event.on(document.body, 'editor:drag-start', 'wb-step, wb-step *, wb-context, wb
 Event.on(document.body, 'editor:dragging', null, dragBlock);
 Event.on(document.body, 'editor:drag-end', null, endDragBlock);
 Event.on(document.body, 'editor:drag-cancel', null, cancelDragBlock);
+
+requestAnimationFrame(checkForScroll);
+
 
 Event.on(workspace, 'editor:input', 'input', resizeInputOnChange);
 Event.on(workspace, 'editor:input', 'input, select', changeValueOnInputChange);

--- a/js/event.js
+++ b/js/event.js
@@ -216,6 +216,7 @@
                 }else{
                     evt.invalid = true;
                     evt.invalidReason = 'Multiple touches present';
+                    console.log('multiple touches');
                     return evt;
                 }
                 evt.target = touch.target;

--- a/playground.html
+++ b/playground.html
@@ -1079,7 +1079,6 @@
             <wb-splitter></wb-splitter>
             <wb-workspace>
                 <header>Workspace</header>
-                <output class="feedback"></output>
                 <wb-contains></wb-contains>
             </wb-workspace>
         </wb-workbox>
@@ -1120,6 +1119,7 @@
         </wb-displaybox>
         </wb-vbox>
     </wb-hbox>
+    <output class="feedback"></output>
     <svg class="sekrit-svg"><text class="resize-tester"></text></svg>
     <!-- polyfill for custom elements -->
     <script src="lib/ajax.js"></script>


### PR DESCRIPTION
Scroll the script area while dragging if the mouse is outside the script area. I'm curious how well this works in practice, there may be edge cases I haven't considered.

Also moved the output box to the bottom to make it more visible (and to give an area outside of the script area to put mouse to trigger scrolling).