### PR TITLE
Fix for https://github.com/waterbearlang/waterbear/issues/1167

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1201,6 +1201,10 @@ function resetDragging(){
     }
     if (origTarget){
         origTarget.classList.remove('hide');
+        var siblingInput = dom.child(origTarget.parentElement, 'input, select');
+        if (siblingInput){
+            siblingInput.classList.add('hide');
+        }
     }
     dragTarget = null;
     origTarget = null;

--- a/js/block.js
+++ b/js/block.js
@@ -1134,6 +1134,9 @@ function endDragBlock(evt){
         // No legal target, probably outside of workspace
         return cancelDragBlock();
     }
+    if(dropTarget === originalParent){
+        return cancelDragBlock();
+    }
     if (dropTarget === BLOCK_MENU){
         // Drop on script menu to delete block, always delete clone
         deleteOriginalBlock(originalBlock, originalParent, nextElem);
@@ -1201,9 +1204,12 @@ function resetDragging(){
     }
     if (origTarget){
         origTarget.classList.remove('hide');
-        var siblingInput = dom.child(origTarget.parentElement, 'input, select');
-        if (siblingInput){
-            siblingInput.classList.add('hide');
+        if(origTarget.parentElement){
+            // Hide the sibling input
+            var siblingInput = dom.child(origTarget.parentElement, 'input, select');
+            if (siblingInput){
+                siblingInput.classList.add('hide');
+            }
         }
     }
     dragTarget = null;


### PR DESCRIPTION
Cancelling when dragging a block by either hitting `esc` or dragging back to the original spot will no longer display the input box.