### PR TITLE
Fixes #1183 by eliminating removed event, fixing removedChild event

### DIFF
--- a/docs/custom_events.md
+++ b/docs/custom_events.md
@@ -14,9 +14,9 @@ Fired when a block is added to a script. When a block is moved, it is removed, t
 
 Fired when a block in a script is modified (i.e., it's socket values are changed).
 
-## wb-remove
+## wb-removedChild
 
-Fired when a block is removed from a script. Moving a block fires both a remove and an add event.
+Fired when a block is removed from a script. Moving a block fires both a removedChild and an add event.
 
 ## wb-delete
 
@@ -45,5 +45,3 @@ Fired when there is a change to one of the state variables (???)
 ## wb-ready
 
 Fired when all the async components (ide, stage, script) have reported in that they're ready.
-
-

--- a/js/block.js
+++ b/js/block.js
@@ -77,7 +77,7 @@ BlockProto.createdCallback = function blockCreated(){
 BlockProto.attachedCallback = function blockAttached(){
     // Attached only fires the first time an element is added to the DOM
     // If you want a notification every time block is added to DOM (moved, etc.) use wb-added
-    // (also wb-removed, wb-addedChild, wb-removedChild)
+    // (also wb-addedChild, wb-removedChild [NOT wb-removed])
     // Attached will fire when re-loading a script too, so program defensively
     // Add locals
     // Make sure they have unique names in scope
@@ -410,8 +410,9 @@ ExpressionProto.detachedCallback = function expressionDetached(){
     }
     if (this.parent.localName !== 'wb-local'){
         var blockParent = dom.closest(this.parent, 'wb-expression, wb-step, wb-context');
+        // FIXME: Is this needed or was it a workaround for wb-removedChild not firing?
         if (blockParent){
-            Event.trigger(blockParent, 'wb-removed', this);
+            Event.trigger(blockParent, 'wb-removedChild', this);
         }
     }
     this.parent = null;
@@ -1338,13 +1339,16 @@ function selectByBlock(block){
 
 // Event handling
 
-// Make sure wb-added, wb-removed, wb-addedChild, wb-removedChild events are triggered
+// Make sure wb-added, wb-addedChild, wb-removedChild events are triggered
 // signature is container, prefix, parentList, elementList
 Event.registerElementsForAddRemoveEvents(workspace, 'wb-', 'wb-step, wb-context, wb-expression, wb-contains', 'wb-step, wb-context, wb-expression');
 
 Event.on(workspace, 'editor:wb-added', 'wb-expression', updateVariableType);
 Event.on(workspace, 'editor:wb-added', 'wb-context, wb-step', uniquifyVariableNames);
 Event.on(document.body, 'editor:wb-cloned', '[fn="getVariable"]', createLocalToInstanceAssociation);
+Event.on(workspace, 'editor:wb-removedChild', 'wb-contains, wb-context, wb-step, wb-expression', function(evt){
+    console.log('caught wb-removedChild: %o', evt);
+});
 
 Event.on(workspace, 'editor:click', 'wb-disclosure', toggleClosed);
 

--- a/js/block.js
+++ b/js/block.js
@@ -408,13 +408,6 @@ ExpressionProto.detachedCallback = function expressionDetached(){
             sib.classList.remove('hide');
         });
     }
-    if (this.parent.localName !== 'wb-local'){
-        var blockParent = dom.closest(this.parent, 'wb-expression, wb-step, wb-context');
-        // FIXME: Is this needed or was it a workaround for wb-removedChild not firing?
-        if (blockParent){
-            Event.trigger(blockParent, 'wb-removedChild', this);
-        }
-    }
     this.parent = null;
 };
 
@@ -1346,9 +1339,6 @@ Event.registerElementsForAddRemoveEvents(workspace, 'wb-', 'wb-step, wb-context,
 Event.on(workspace, 'editor:wb-added', 'wb-expression', updateVariableType);
 Event.on(workspace, 'editor:wb-added', 'wb-context, wb-step', uniquifyVariableNames);
 Event.on(document.body, 'editor:wb-cloned', '[fn="getVariable"]', createLocalToInstanceAssociation);
-Event.on(workspace, 'editor:wb-removedChild', 'wb-contains, wb-context, wb-step, wb-expression', function(evt){
-    console.log('caught wb-removedChild: %o', evt);
-});
 
 Event.on(workspace, 'editor:click', 'wb-disclosure', toggleClosed);
 

--- a/js/event.js
+++ b/js/event.js
@@ -234,8 +234,10 @@
             mutations.forEach(function(mutation){
                 // send childAdded or childRemove event to parent element
                 var parent = mutation.target;
-                // WARNING: Node.contains may not be supported on mobile
-                // Polyfill if needed
+                // if (!Node.contains){
+                //     console.error('Node.contains not found');
+                //     console.error('Find a polyfill');
+                // }
                 if (!root.contains(parent)){
                     return;
                 }
@@ -243,11 +245,14 @@
                 if (!blockParent){
                     return;
                 }
+                console.log(mutation);
                 [].slice.apply(mutation.removedNodes)
                         .filter(function(node){return node.nodeType === node.ELEMENT_NODE && dom.matches(node, childList)}) // only child elements
                         .forEach(function(node){
                     Event.trigger(blockParent, eventPrefix + 'removedChild', node);
-                    Event.trigger(node, eventPrefix + 'removed', blockParent);
+                    // This won't bubble through the tree because the node is
+                    // not in the tree anymore
+                    //Event.trigger(node, eventPrefix + 'removed', blockParent);
                 });
                 [].slice.apply(mutation.addedNodes)
                         .filter(function(node){return node.nodeType === node.ELEMENT_NODE && dom.matches(node, childList)}) // only block elements

--- a/js/event.js
+++ b/js/event.js
@@ -245,7 +245,6 @@
                 if (!blockParent){
                     return;
                 }
-                console.log(mutation);
                 [].slice.apply(mutation.removedNodes)
                         .filter(function(node){return node.nodeType === node.ELEMENT_NODE && dom.matches(node, childList)}) // only child elements
                         .forEach(function(node){

--- a/js/file.js
+++ b/js/file.js
@@ -240,7 +240,7 @@
     if (page === 'playground'){
         Event.on(window, 'ui:beforeunload', null, saveCurrentScripts);
         Event.on(document.body, 'ui:wb-added', null, bareUrl); // Remove gist or other argument on script change
-        Event.on(document.body, 'ui:wb-removed', null, bareUrl);
+        Event.on(document.body, 'ui:wb-removedChild', null, bareUrl);
         Event.on(document.body, 'ui:wb-changed', null, bareUrl);
     }
 

--- a/js/widget.js
+++ b/js/widget.js
@@ -164,30 +164,5 @@ Event.on(window, 'ui:dblclick', 'wb-splitter', function(evt){
     }
 });
 
-// Observe child changes
-
-var observer = new MutationObserver(function(mutations){
-    mutations.forEach(function(mutation){
-        // send childAdded or childRemove event to parent element
-        // should I filter this to only elements (otherwise text nodes will be included)?
-        var parent = mutation.target;
-        [].slice.apply(mutation.removedNodes).forEach(function(node){
-            parent.dispatchEvent(new CustomEvent('removeChild', {
-                bubbles: true,
-                detail: node
-            }));
-        });
-        [].slice.apply(mutation.addedNodes).forEach(function(node){
-            parent.dispatchEvent(new CustomEvent('addChild', {
-                bubbles: true,
-                detail: node
-            }));
-        });
-    });
-});
-
-var config = { childList: true, subtree: true };
-
-// observer.observe(document.body, config);
 
 })();


### PR DESCRIPTION
The removed event was never bubbling (so it couldn't be caught via event delegation) because the node it was being fired on was no longer in the tree at that point (seems kind of obvious in hindsight).

Removed the `removed` event so we don't try to rely on it again, and replaced uses of it with `removedChild` after confirming it *does* work, and fixing up some selectors to make sure we catch it.

Have looked for and removed any old workarounds (that I found) we had for this functionality not working before.