### PR TITLE
Fix for #1197

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -689,10 +689,12 @@ function addItem(evt){
 ******************/
 
 function removeItem(evt){
+    //debugger;
     var self = evt.target;
     var row = dom.closest(self, 'wb-row');
     // we want to remove the row, but not if it is the last one
-    if (row.previousElementSibling || row.nextElementSibling){
+    if (row.previousElementSibling || (row.nextElementSibling &&
+            row.nextElementSibling.localName === 'wb-row')){
         row.parentElement.removeChild(row);
     }
 }

--- a/js/block.js
+++ b/js/block.js
@@ -689,7 +689,6 @@ function addItem(evt){
 ******************/
 
 function removeItem(evt){
-    //debugger;
     var self = evt.target;
     var row = dom.closest(self, 'wb-row');
     // we want to remove the row, but not if it is the last one


### PR DESCRIPTION
Looking at the comment above the if, that if statement should stop that last element from being deleted by checking if it had siblings, but because there was always a `create array` text field sibling, it would always deleted. 