### PR TITLE
Fix keyboard shortcut for undo in Chrome

### DIFF
--- a/js/event.js
+++ b/js/event.js
@@ -380,9 +380,12 @@
 
     var specialKeys = {
         // taken from jQuery Hotkeys Plugin
+        // updated because browsers suck, meta returned for 4 different values
+        // see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#Non-printable_keys_%28function_keys%29
         8: "backspace", 9: "tab", 13: "return", 16: "shift", 17: "ctrl", 18: "alt", 19: "pause",
         20: "capslock", 27: "esc", 32: "space", 33: "pageup", 34: "pagedown", 35: "end", 36: "home",
         37: "left", 38: "up", 39: "right", 40: "down", 45: "insert", 46: "del",
+        91: "meta", 92: "meta", 93: "meta", // left and right commands
         96: "0", 97: "1", 98: "2", 99: "3", 100: "4", 101: "5", 102: "6", 103: "7",
         104: "8", 105: "9", 106: "*", 107: "+", 109: "-", 110: ".", 111 : "/",
         112: "f1", 113: "f2", 114: "f3", 115: "f4", 116: "f5", 117: "f6", 118: "f7", 119: "f8",


### PR DESCRIPTION
Different browser/platform combos return different keycodes for Command (on Mac) / Windows key / Meta (on Linux). All of these are now mapped to "meta" in our code, so 'cmd'-z and 'meta'-z can both be mapped to `undo` and work across browsers and platforms. The old way was working on Mac in Firefox, but not in Chrome, now it should work everywhere.