### PR TITLE
1174 double get variable

### DIFF
--- a/js/runtime.js
+++ b/js/runtime.js
@@ -1103,19 +1103,25 @@
                 return new Date(year, month-1, day);
             },
             now: function () {
-                var today = new Date()
+                var today = new Date();
+                // Seems like "now" should have time as well, but
+                // maybe "today" shouldn't?
                 today.setHours(0, 0, 0, 0)
                 return today;
             },
-            addDays: function (date, days) {
-                date.setDate(date.getDate() + days);
+            addDays: function (prevDate, days) {
+                // we don't want to mutate an argument in place
+                var date = new Date(prevDate.valueOf()); // clone argument
+                date.setDate(prevDate.getDate() + days);
                 return date;
             },
-            addMonths: function (date, months) {
+            addMonths: function (prevDate, months) {
+                var date = new Date(prevDate.valueOf());
                 date.setMonth(date.getMonth() + months);
                 return date;
             },
-            addYears: function (date, years) {
+            addYears: function (prevDate, years) {
+                var date = new Date(prevDate.valueOf());
                 date.setFullYear(date.getFullYear() + years);
                 return date;
             }

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -73,7 +73,6 @@
     function clearRuntime() {
         /* FIXME: Event.clearRuntime() should be moved to runtime.js.
          * See: https://github.com/waterbearlang/waterbear/issues/968 */
-        // console.log('clearing runtime');
         Event.clearRuntime();
         clearPerFrameHandlers();
         /* Clear all runtime event handlers. */
@@ -107,11 +106,13 @@
 
     function stopEventLoop() {
         /* TODO: Dunno lol there be more in here? */
-        // console.log('stop event loop');
     }
 
     function frameHandler(timestamp){
         // where to put these? Event already has some global state.
+        if (lastTime === timestamp){
+            throw new Exception('There can be only one!');
+        }
         runtime.control._elapsed = timestamp - runtime.control._startTime;
         runtime.control._sinceLastTick = timestamp - lastTime;
         runtime.control._frame++;
@@ -120,7 +121,7 @@
             handler();
         });
         if (perFrameHandlers.length){
-            requestAnimationFrame(frameHandler);
+            animationFrameHandler = requestAnimationFrame(frameHandler);
         }
     }
 
@@ -402,6 +403,7 @@
                 runtime.control.setVariable(name, answer);
             },
             comment: function controlCommentStep(){
+                // do nothing, it's a comment
             },
             log: function controlLogStep(item){
                 console.log(item);
@@ -799,7 +801,6 @@
                 return assets.sounds[url]; // already cached by sounds library
             },
             play: function(sound){
-                // console.log('sound.play()');
                 sound.play();
             },
             setLoop: function(sound, flag){


### PR DESCRIPTION
OK, finally tracked it down for sure.

I thought errors in the new Date blocks were a clue, but that was just a problem I missed in the code review: we were mutating the arguments, so they were getting changed over and over. I fixed that to clone the arguments instead and date blocks work fine now.

Then I dug some more into the per-frame runtime. I had put some code in last time I worked on this to ensure there was only one handler registered at a time, and to delete that handler when we restarted the script. I put in a quick test to make sure this was working, and that test failed. So I tracked it down to one place where I had forgotten to update the variable holding the current frame runner. Fixed that spot, ran the test and all was well. Could hit play any number of times and the waterbear wouldn't speed up. The Simple Bounce is always going the same speed now too.