### PR TITLE
Fix function of input limiter to reference max/min value of input box

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1339,10 +1339,11 @@ function selectByBlock(block){
 
 function handleInputOnBalance(evt) {
     var input = dom.closest(evt.target, 'input');
-    if(input.value < -1) input.value = -1;
-    if(input.value > 1) input.value = 1;
-}
-    
+    if(input.min || input.max ) {
+        if(input.value < input.min) input.value = input.min;  
+        if(input.value > input.max) input.value = input.max;
+    }
+}   
 // Event handling
 
 // Make sure wb-added, wb-removed, wb-addedChild, wb-removedChild events are triggered


### PR DESCRIPTION
This is an update to an earlier fix. The other fix was incomplete and made all inputs only be able to go from 1 to -1.