### PR TITLE
Fixed the input not showing problem

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1337,11 +1337,15 @@ function selectByBlock(block){
 
 function handleInputOnBalance(evt) {
     var input = dom.closest(evt.target, 'input');
-    if(input.min || input.max ) {
-        if(input.value < input.min) input.value = input.min;  
-        if(input.value > input.max) input.value = input.max;
+    if(input.min && input.value < input.min)
+    {
+        input.value = input.min;
     }
-}  
+    else if(input.max && input.value > input.max)
+    {
+        input.value = input.max;
+    }
+}
 
 function handleEnter(evt) {
     var code = (evt.keyCode ? evt.keyCode : evt.which);


### PR DESCRIPTION
The rectangle block only had a min, so `input.min || input.max` was true, but `input.value > input.max` was also true. So `input.value = input.max;` would run but since there's nothing in `max`, nothing would show on the user end.

My fix is to only do the comparison when there is a value to compare.