### PR TITLE
Collision block

### DIFF
--- a/example/simple_pong.wb
+++ b/example/simple_pong.wb
@@ -1,0 +1,298 @@
+<wb-step ns="control" fn="setVariable" class=""><header><wb-row>
+                        <wb-value>set</wb-value>
+						<wb-local renameable="true">
+							<wb-expression type="sprite" ns="control" fn="getVariable" id="k47a23e" class=""><header><wb-value type="text" allow="literal" value="bottom block" class="" selected="true"><input type="text" style="width: 79.7109px;" class=""></wb-value></header>
+								
+							</wb-expression>
+						</wb-local>
+                        <wb-value type="any" class="">to<input type="any" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="sprite" fn="create" class="" style=""><header><wb-value type="wb-image,shape,sprite" class="">sprite with<input type="wb-image" readonly="" style="width: 30px;" class="hide"><wb-expression type="shape" ns="shape" fn="rectangle" filtered="true" class="" style=""><header><wb-value type="vector" class="">rectangle at<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="zeroVector" filtered="true" class="" style=""><header><wb-value class="">zero vector &lt;0,0&gt;</wb-value></header>
+					
+				</wb-expression></wb-value><wb-value type="number" class="" value="100" selected="true">width<input type="number" style="width: 33.02px;"></wb-value><wb-value type="number" class="" value="20">height<input type="number" style="width: 30px;"></wb-value><wb-value type="list" allow="literal" options="center,corner" value="center" class="">orientation<select style="width: 46.4126px;"><option>center</option><option selected="selected">corner</option></select></wb-value></header>
+                    
+                    
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                </wb-expression></wb-value>
+                    </wb-row></header>
+                    
+                </wb-step><wb-step ns="control" fn="setVariable" class=""><header><wb-row>
+                        <wb-value>set</wb-value>
+						<wb-local renameable="true">
+							<wb-expression type="sprite" ns="control" fn="getVariable" id="keee160" class=""><header><wb-value type="text" allow="literal" value="top block" class=""><input type="text" style="width: 60.5576px;" class=""></wb-value></header>
+								
+							</wb-expression>
+						</wb-local>
+                        <wb-value type="any" class="">to<input type="any" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="sprite" fn="create" class="" style=""><header><wb-value type="wb-image,shape,sprite" class="">sprite with<input type="wb-image" readonly="" style="width: 30px;" class="hide"><wb-expression type="shape" ns="shape" fn="rectangle" filtered="true" class="" style=""><header><wb-value type="vector" class="">rectangle at<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="zeroVector" filtered="true" class="" style=""><header><wb-value>zero vector &lt;0,0&gt;</wb-value></header>
+					
+				</wb-expression></wb-value><wb-value type="number" min="0" class="" value="100" selected="true">width<input type="number" min="0" style="width: 33.02px;"></wb-value><wb-value type="number" min="0" class="" selected="true" value="20">height<input type="number" min="0" style="width: 30px;"></wb-value><wb-value type="list" allow="literal" options="center,corner" value="center" class="">orientation<select style="width: 46.8022px;"><option>center</option><option selected="selected">corner</option></select></wb-value></header>
+                    
+                    
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                </wb-expression></wb-value>
+                    </wb-row></header>
+                    
+                </wb-step><wb-step ns="control" fn="setVariable" class=""><header><wb-row>
+                        <wb-value>set</wb-value>
+						<wb-local renameable="true">
+							<wb-expression type="sprite" ns="control" fn="getVariable" id="kb0fcb3" class=""><header><wb-value type="text" allow="literal" value="sprite" class=""><input type="text" style="width: 42.2764px;" class=""></wb-value></header>
+								
+							</wb-expression>
+						</wb-local>
+                        <wb-value type="any" class="">to<input type="any" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="sprite" fn="create" class=""><header><wb-value type="wb-image,shape,sprite" class="">sprite with<input type="wb-image" readonly="" style="width: 30px;" class="hide"><wb-expression type="shape" ns="shape" fn="circle" filtered="true" class="" style=""><header><wb-value type="vector" class="">circle at<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="zeroVector" filtered="true" class="" style=""><header><wb-value>zero vector &lt;0,0&gt;</wb-value></header>
+					
+				</wb-expression></wb-value><wb-value type="number" min="0" class="" selected="true" value="20">radius<input type="number" min="0" style="width: 30px;"></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                </wb-expression></wb-value>
+                    </wb-row></header>
+                    
+                </wb-step><wb-step ns="sprite" fn="moveTo" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k6279c7" class="" instanceof="kb0fcb3" style=""><header><wb-value type="text" allow="literal" value="sprite" class="">sprite</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">move to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="randomPoint" class="" style=""><header><wb-value>random point</wb-value></header>
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-step><wb-step ns="sprite" fn="moveTo" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k19f5d4" class="" instanceof="k47a23e" style=""><header><wb-value type="text" allow="literal" value="bottom block" class="">bottom block</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">move to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="create" filtered="true" class="" style=""><header><wb-value type="number" value="0" class="">vector at x<input type="number" style="width: 30px;" class="hide"><wb-expression type="number" ns="stage" fn="centerX" filtered="true" class="" style=""><header><wb-value>Center x</wb-value></header>
+					
+				</wb-expression></wb-value><wb-value type="number" value="0" class="">y<input type="number" style="width: 30px;" class="hide"><wb-expression ns="math" type="number" fn="subtract" filtered="true" class="" style=""><header><wb-value type="number,vector,array,date" value="0" class=""><input type="number" style="width: 30px;" class="hide"><wb-expression type="number" ns="stage" fn="stageHeight" filtered="true" class="" style=""><header><wb-value>Stage Height</wb-value></header>
+					
+				</wb-expression></wb-value><wb-value type="number,vector,array,date" value="20" class="" selected="true">−<input type="number" style="width: 30px;"></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-step><wb-step ns="sprite" fn="moveTo" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k3641db" class="" instanceof="keee160" style=""><header><wb-value type="text" allow="literal" value="top block" class="">top block</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">move to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="create" filtered="true" class="" style=""><header><wb-value type="number" value="0" class="">vector at x<input type="number" style="width: 30px;" class="hide"><wb-expression type="number" ns="stage" fn="centerX" filtered="true" class="" style=""><header><wb-value>Center x</wb-value></header>
+					
+				</wb-expression></wb-value><wb-value type="number" value="20" class="" selected="true">y<input type="number" style="width: 30px;"></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-step><wb-step ns="sprite" fn="setVelocity" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k95fb1a" class="" instanceof="kb0fcb3" style=""><header><wb-value type="text" allow="literal" value="sprite" class="">sprite</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">set velocity to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="math" fn="multiply" class=""><header><wb-value type="vector" class=""><input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="randomUnitVector" class=""><header><wb-value>random unit vector</wb-value></header>
+                    
+                </wb-expression></wb-value><wb-value type="number" value="10" class="" selected="true">×<input type="number" style="width: 30px;"></wb-value></header>
+					<!-- FIXME: Temporary workaround until type propagation works for math * -->
+					
+                    
+				</wb-expression></wb-value></header>
+                    
+                    
+                </wb-step><wb-step ns="color" fn="fill" class="" style=""><header><wb-value type="color" value="#0000FF" class="">fill style<input type="color" style="width: 51.9126px;"></wb-value></header>
+                    
+                </wb-step><wb-context ns="control" toplevel="true" fn="eachFrame" class="" style=""><header><wb-disclosure></wb-disclosure><wb-row>
+                        <wb-value>each frame</wb-value>
+                    </wb-row><wb-row>
+                        <wb-local>
+                            <wb-expression type="number" ns="control" fn="frame" id="k2456e7"><header><wb-value value="frame">frame</wb-value></header>
+                                
+                            </wb-expression>
+                        </wb-local>
+                        <wb-local>
+                            <wb-expression type="number" ns="control" fn="elapsed" id="k4b8817" class=""><header><wb-value value="elapsed" class="">elapsed</wb-value></header>
+                                
+                            </wb-expression>
+                        </wb-local>
+                    </wb-row></header>
+                    
+                    
+                <wb-contains class=""><wb-step ns="stage" fn="clearTo" class="" style=""><header><wb-value type="color,wb-image,shape" class="">clear to<input type="color" style="width: 57.7256px;" class=""></wb-value></header>
+                    
+                </wb-step><wb-step ns="sprite" fn="move" class="" style=""><header><wb-value type="sprite" class="">move<input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="kf83c25" class="" instanceof="keee160" style=""><header><wb-value type="text" allow="literal" value="top block" class="">top block</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                </wb-step><wb-step ns="sprite" fn="move" class="" style=""><header><wb-value type="sprite" class="">move<input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k10c4f7" class="" instanceof="k47a23e" style=""><header><wb-value type="text" allow="literal" value="bottom block" class="" selected="true">bottom block</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                </wb-step><wb-step ns="sprite" fn="move" class="" style=""><header><wb-value type="sprite" class="">move<input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k41da19" class="" instanceof="kb0fcb3" style=""><header><wb-value type="text" allow="literal" value="sprite" class="">sprite</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                </wb-step><wb-step ns="sprite" fn="draw" class="" style=""><header><wb-value type="sprite" class="">draw<input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="ke1df86" class="" instanceof="keee160" style=""><header><wb-value type="text" allow="literal" value="top block" class="">top block</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                </wb-step><wb-step ns="sprite" fn="draw" class="" style=""><header><wb-value type="sprite" class="">draw<input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k1b81b1" class="" instanceof="k47a23e" style=""><header><wb-value type="text" allow="literal" value="bottom block" class="">bottom block</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                </wb-step><wb-step ns="sprite" fn="draw" class="" style=""><header><wb-value type="sprite" class="">draw<input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="kf91285" class="" instanceof="kb0fcb3" style=""><header><wb-value type="text" allow="literal" value="sprite" class="">sprite</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                </wb-step><wb-step ns="sprite" fn="bounceAtEdge" class="" style=""><header><wb-value type="sprite" class="">bounce at edge<input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="kde0c84" class="" instanceof="kb0fcb3" style=""><header><wb-value type="text" allow="literal" value="sprite" class="">sprite</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                </wb-step><wb-step ns="sprite" fn="setVelocity" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k2342d2" class="" instanceof="k47a23e" style=""><header><wb-value type="text" allow="literal" value="bottom block" class="" selected="true">bottom block</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">set velocity to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="createPolar" filtered="true" class="" style=""><header><wb-value type="number" value="0" class="">vector at angle<input type="number" style="width: 30px;"></wb-value><wb-value type="number" value="0" class="">magnitude<input type="number" style="width: 30px;"></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-step><wb-step ns="sprite" fn="setVelocity" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k65bcf1" class="" instanceof="keee160" style=""><header><wb-value type="text" allow="literal" value="top block" class="">top block</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">set velocity to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="createPolar" filtered="true" class="" style=""><header><wb-value type="number" value="0" class="">vector at angle<input type="number" style="width: 30px;"></wb-value><wb-value type="number" value="0" class="">magnitude<input type="number" style="width: 30px;"></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-step><wb-context ns="control" fn="if" class="" style=""><header><wb-disclosure></wb-disclosure><wb-value type="boolean" value="true" class="">if<select style="width: 34.0152px;" class="hide"><option selected="selected">true</option><option>false</option></select><wb-expression type="boolean" ns="boolean" fn="or" filtered="true" class="" style=""><header><wb-value type="boolean" value="true" class=""><select style="width: 34.6045px;" class="hide"><option selected="selected">true</option><option>false</option></select><wb-expression type="boolean" ns="sprite" fn="checkForCollision" class=""><header><wb-value type="sprite" class="">is collision<input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="kb1f9b1" class="" instanceof="kb0fcb3" style=""><header><wb-value type="text" allow="literal" value="sprite" class="">sprite</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k9383bb" class="" instanceof="k47a23e" style=""><header><wb-value type="text" allow="literal" value="bottom block" class="">bottom block</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value><wb-value type="boolean" value="false" class="">or<select style="width: 34.6045px;" class="hide"><option selected="selected">true</option><option>false</option></select><wb-expression type="boolean" ns="sprite" fn="checkForCollision" filtered="true" class="" style=""><header><wb-value type="sprite" class="">is collision<input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k15d135" class="" instanceof="keee160" style=""><header><wb-value type="text" allow="literal" value="top block" class="">top block</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k9391d9" class="" instanceof="kb0fcb3" style=""><header><wb-value type="text" allow="literal" value="sprite" class="">sprite</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                <wb-contains class=""><wb-step ns="control" fn="setVariable" class=""><header><wb-row>
+                        <wb-value>set</wb-value>
+						<wb-local renameable="true">
+							<wb-expression type="number" ns="control" fn="getVariable" id="kdc4ffb" class=""><header><wb-value type="text" allow="literal" value="deg" class="" selected="true"><input type="text" style="width: 33.7773px;" class=""></wb-value></header>
+								
+							</wb-expression>
+						</wb-local>
+                        <wb-value type="any" class="">to<input type="any" style="width: 30px;" class="hide"><wb-expression type="number" ns="vector" fn="degrees" filtered="true" class=""><header><wb-value type="vector" class="">degrees<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="sprite" fn="getVelocity" filtered="true" class="" style=""><header><wb-value type="sprite" class="">get velocity<input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="kead73e" class="" instanceof="kb0fcb3" style=""><header><wb-value type="text" allow="literal" value="sprite" class="">sprite</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+					
+				</wb-expression></wb-value></header>
+                    
+                </wb-expression></wb-value>
+                    </wb-row></header>
+                    
+                </wb-step><wb-step ns="control" fn="setVariable" class=""><header><wb-row>
+                        <wb-value>set</wb-value>
+						<wb-local renameable="true">
+							<wb-expression type="number" ns="control" fn="getVariable" id="kadbc1b" class=""><header><wb-value type="text" allow="literal" value="delta" class=""><input type="text" style="width: 39.2666px;" class=""></wb-value></header>
+								
+							</wb-expression>
+						</wb-local>
+                        <wb-value type="any" class="">to<input type="any" style="width: 30px;" class="hide"><wb-expression ns="math" type="number" fn="subtract" filtered="true" class="" style=""><header><wb-value type="number,vector,array,date" value="180" class="" selected="true"><input type="number" style="width: 33.1167px;"></wb-value><wb-value type="number,vector,array,date" value="0" class="">−<input type="number" style="width: 30px;" class="hide"><wb-expression type="number" ns="control" fn="getVariable" id="k3a2ed5" class="" instanceof="kdc4ffb" style=""><header><wb-value type="text" allow="literal" value="deg" class="" selected="true">deg</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value>
+                    </wb-row></header>
+                    
+                </wb-step><wb-step ns="control" fn="setVariable" class=""><header><wb-row>
+                        <wb-value>set</wb-value>
+						<wb-local renameable="true">
+							<wb-expression type="vector" ns="control" fn="getVariable" id="kc86e0b" class=""><header><wb-value type="text" allow="literal" value="velocity" class=""><input type="text" style="width: 52.7695px;"></wb-value></header>
+								
+							</wb-expression>
+						</wb-local>
+                        <wb-value type="any" class="">to<input type="any" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="createPolar" filtered="true" class=""><header><wb-value type="number" value="270" class="">vector at angle<input type="number" style="width: 33.874px;" class="hide"><wb-expression ns="math" type="number" fn="add" filtered="true" class="" style=""><header><wb-value type="number,vector,array" value="180" class="" selected="true"><input type="number" style="width: 33.1167px;"></wb-value><wb-value type="number,vector,array" value="0" class="">+<input type="number" style="width: 30px;" class="hide"><wb-expression type="number" ns="control" fn="getVariable" id="kc3904b" class="" instanceof="kadbc1b" style=""><header><wb-value type="text" allow="literal" value="delta" class="">delta</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value><wb-value type="number" value="10" class="" selected="true">magnitude<input type="number" style="width: 30px;"></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value>
+                    </wb-row></header>
+                    
+                </wb-step><wb-step ns="sprite" fn="setVelocity" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="ka56f70" class="" instanceof="kb0fcb3" style=""><header><wb-value type="text" allow="literal" value="sprite" class="">sprite</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">set velocity to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="control" fn="getVariable" id="k709694" class="" instanceof="kc86e0b" style=""><header><wb-value type="text" allow="literal" value="velocity" class="">velocity</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                    
+                </wb-step></wb-contains></wb-context><wb-step ns="control" fn="setVariable" class="selected-block"><header><wb-row>
+                        <wb-value>set</wb-value>
+						<wb-local renameable="true">
+							<wb-expression type="number" ns="control" fn="getVariable" id="k3225c0" class=""><header><wb-value type="text" allow="literal" value="speed" class=""><input type="text" style="width: 45.1748px;" class=""></wb-value></header>
+								
+							</wb-expression>
+						</wb-local>
+                        <wb-value type="any" class="selected-value" value="8" selected="true">to<input type="any" style="width: 30px;" class=""></wb-value>
+                    </wb-row></header>
+                    
+                </wb-step><wb-context ns="control" fn="if" class="" style=""><header><wb-disclosure></wb-disclosure><wb-value type="boolean" value="true" class="">if<select style="width: 34.6045px;" class="hide"><option selected="selected">true</option><option>false</option></select><wb-expression type="boolean" ns="input" fn="keyPressed" filtered="true" class="" style=""><header><wb-value type="list" allow="literal" value="left" options="a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,*,+,-,.,/,up,down,left,right,backspace,tab,return,shift,ctrl,alt,pause,capslock,esc,space,pageup,pagedown,end,home,insert,del,numlock,scroll,meta" class=""> Key<select style="width: 30px;"><option selected="selected">a</option><option>b</option><option>c</option><option>d</option><option>e</option><option>f</option><option>g</option><option>h</option><option>i</option><option>j</option><option>k</option><option>l</option><option>m</option><option>n</option><option>o</option><option>p</option><option>q</option><option>r</option><option>s</option><option>t</option><option>u</option><option>v</option><option>w</option><option>x</option><option>y</option><option>z</option><option>*</option><option>+</option><option>-</option><option>.</option><option>/</option><option>up</option><option>down</option><option>left</option><option>right</option><option>backspace</option><option>tab</option><option>return</option><option>shift</option><option>ctrl</option><option>alt</option><option>pause</option><option>capslock</option><option>esc</option><option>space</option><option>pageup</option><option>pagedown</option><option>end</option><option>home</option><option>insert</option><option>del</option><option>numlock</option><option>scroll</option><option>meta</option></select></wb-value><wb-value>Pressed?</wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                <wb-contains class=""><wb-step ns="sprite" fn="setVelocity" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="kcc35d9" class="" instanceof="keee160" style=""><header><wb-value type="text" allow="literal" value="top block" class="">top block</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">set velocity to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="createPolar" filtered="true" class="" style=""><header><wb-value type="number" value="180" class="" selected="true">vector at angle<input type="number" style="width: 33.1167px;"></wb-value><wb-value type="number" value="0" class="">magnitude<input type="number" style="width: 30px;" class="hide"><wb-expression type="number" ns="control" fn="getVariable" id="kd2ba8d" class="" instanceof="k3225c0" style=""><header><wb-value type="text" allow="literal" value="speed" class="">speed</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-step><wb-step ns="sprite" fn="setVelocity" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k9b10ff" class="" instanceof="k47a23e" style=""><header><wb-value type="text" allow="literal" value="bottom block" class="" selected="true">bottom block</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">set velocity to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="createPolar" filtered="true" class="" style=""><header><wb-value type="number" value="180" class="">vector at angle<input type="number" style="width: 33.1167px;"></wb-value><wb-value type="number" value="0" class="">magnitude<input type="number" style="width: 30px;" class="hide"><wb-expression type="number" ns="control" fn="getVariable" id="k804fbe" class="" instanceof="k3225c0" style=""><header><wb-value type="text" allow="literal" value="speed" class="">speed</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-step></wb-contains></wb-context><wb-context ns="control" fn="if" class="" style=""><header><wb-disclosure></wb-disclosure><wb-value type="boolean" value="true" class="">if<select style="width: 34.6045px;" class="hide"><option selected="selected">true</option><option>false</option></select><wb-expression type="boolean" ns="input" fn="keyPressed" filtered="true" class="" style=""><header><wb-value type="list" allow="literal" value="right" options="a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,*,+,-,.,/,up,down,left,right,backspace,tab,return,shift,ctrl,alt,pause,capslock,esc,space,pageup,pagedown,end,home,insert,del,numlock,scroll,meta" class=""> Key<select style="width: 30px;" class=""><option selected="selected">a</option><option>b</option><option>c</option><option>d</option><option>e</option><option>f</option><option>g</option><option>h</option><option>i</option><option>j</option><option>k</option><option>l</option><option>m</option><option>n</option><option>o</option><option>p</option><option>q</option><option>r</option><option>s</option><option>t</option><option>u</option><option>v</option><option>w</option><option>x</option><option>y</option><option>z</option><option>*</option><option>+</option><option>-</option><option>.</option><option>/</option><option>up</option><option>down</option><option>left</option><option>right</option><option>backspace</option><option>tab</option><option>return</option><option>shift</option><option>ctrl</option><option>alt</option><option>pause</option><option>capslock</option><option>esc</option><option>space</option><option>pageup</option><option>pagedown</option><option>end</option><option>home</option><option>insert</option><option>del</option><option>numlock</option><option>scroll</option><option>meta</option></select></wb-value><wb-value>Pressed?</wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                <wb-contains class=""><wb-step ns="sprite" fn="setVelocity" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="k52b32e" class="" instanceof="keee160" style=""><header><wb-value type="text" allow="literal" value="top block" class="">top block</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">set velocity to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="createPolar" filtered="true" class="" style=""><header><wb-value type="number" value="0" class="">vector at angle<input type="number" style="width: 30px;"></wb-value><wb-value type="number" value="0" class="">magnitude<input type="number" style="width: 30px;" class="hide"><wb-expression type="number" ns="control" fn="getVariable" id="k1046a3" class="" instanceof="k3225c0" style=""><header><wb-value type="text" allow="literal" value="speed" class="">speed</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-step><wb-step ns="sprite" fn="setVelocity" class="" style=""><header><wb-value type="sprite" class=""><input type="sprite" readonly="" style="width: 30px;" class="hide"><wb-expression type="sprite" ns="control" fn="getVariable" id="kb31802" class="" instanceof="k47a23e" style=""><header><wb-value type="text" allow="literal" value="bottom block" class="" selected="true">bottom block</wb-value></header>
+								
+							</wb-expression></wb-value><wb-value type="vector" class="">set velocity to<input type="vector" readonly="" style="width: 30px;" class="hide"><wb-expression type="vector" ns="vector" fn="createPolar" filtered="true" class="" style=""><header><wb-value type="number" value="0" class="">vector at angle<input type="number" style="width: 30px;"></wb-value><wb-value type="number" value="0" class="">magnitude<input type="number" style="width: 30px;" class="hide"><wb-expression type="number" ns="control" fn="getVariable" id="kf5eb78" class="" instanceof="k3225c0" style=""><header><wb-value type="text" allow="literal" value="speed" class="">speed</wb-value></header>
+								
+							</wb-expression></wb-value></header>
+                    
+                    
+                </wb-expression></wb-value></header>
+                    
+                    
+                </wb-step></wb-contains></wb-context></wb-contains></wb-context>

--- a/js/app.js
+++ b/js/app.js
@@ -200,7 +200,8 @@ function handleExampleButton(evt){
                 handleExample('Noise 3D', 'noise3d'),
                 handleExample('Dance', 'dance'),
                 handleExample('Simple Bounce', 'bounce'),
-                handleExample('Simple Move', 'simple_move')
+                handleExample('Simple Move', 'simple_move'),
+                handleExample('Simple Pong', 'simple_pong')
             ]
         }
     );

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -750,8 +750,6 @@
                 return new util.Shape(function(ctx){
                     ctx.beginPath();
                     ctx.arc(pt.x, pt.y, rad, 0, Math.PI * 2, true);
-                    this.x = x;
-                    this.y = y;
                     this.rad = rad;
                 });
             },
@@ -762,11 +760,13 @@
                     var y = 0;
                     if(orientation == "center"){
                         x = pt.x - width/2;
-                        y = pt.y - height/2
+                        y = pt.y - height/2;
+                        this.centered = true;
                     }
                     else{
                         x = pt.x;
                         y = pt.y;
+                        this.centered = false;
                     }
 
                     ctx.moveTo(x, y);
@@ -775,8 +775,6 @@
                     ctx.lineTo(x, y + height);
                     ctx.lineTo(x, y);
 
-                    this.x = x;
-                    this.y = y;
                     this.width = width;
                     this.height = height;
                 });

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -753,25 +753,27 @@
                 });
             },
             rectangle: function(pt, width, height, orientation){
-                //debugger;
                 return new util.Shape(function(ctx){
                     ctx.beginPath();
+                    var x = 0;
+                    var y = 0;
                     if(orientation == "center"){
-                        ctx.moveTo(pt.x - width/2, pt.y - height/2);
-                        ctx.lineTo(pt.x + width/2, pt.y - height/2);
-                        ctx.lineTo(pt.x + width/2, pt.y + height/2);
-                        ctx.lineTo(pt.x - width/2, pt.y + height/2);
-                        ctx.lineTo(pt.x - width/2, pt.y - height/2);
+                        x = pt.x - width/2;
+                        y = pt.y - height/2
                     }
                     else{
-                        ctx.moveTo(pt.x, pt.y);
-                        ctx.lineTo(pt.x + width, pt.y);
-                        ctx.lineTo(pt.x + width, pt.y + height);
-                        ctx.lineTo(pt.x, pt.y + height);
-                        ctx.lineTo(pt.x, pt.y);
+                        x = pt.x;
+                        y = pt.y;
                     }
-                    this.x = pt.x;
-                    this.y = pt.y;
+
+                    ctx.moveTo(x, y);
+                    ctx.lineTo(x + width, y);
+                    ctx.lineTo(x + width, y + height);
+                    ctx.lineTo(x, y + height);
+                    ctx.lineTo(x, y);
+
+                    this.x = x;
+                    this.y = y;
                     this.width = width;
                     this.height = height;
                 });

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -750,9 +750,12 @@
                 return new util.Shape(function(ctx){
                     ctx.beginPath();
                     ctx.arc(pt.x, pt.y, rad, 0, Math.PI * 2, true);
+                    this.x = x;
+                    this.y = y;
+                    this.rad = rad;
                 });
             },
-            rectangle: function(pt, width, height, orientation){
+            rectangle: function rectangle(pt, width, height, orientation){
                 return new util.Shape(function(ctx){
                     ctx.beginPath();
                     var x = 0;

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -746,11 +746,11 @@
             setLineWidth: function(width){
                 getContext().lineWidth = width;
             },
-            circle: function(pt, rad){
+            circle: function circle(pt, rad){
                 return new util.Shape(function(ctx){
                     ctx.beginPath();
                     ctx.arc(pt.x, pt.y, rad, 0, Math.PI * 2, true);
-                    this.rad = rad;
+                    this.radius = rad;
                 });
             },
             rectangle: function rectangle(pt, width, height, orientation){

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -902,6 +902,9 @@
             },
             stopAtEdge: function(spt){
                 spt.stayWithinRect(canvasRect());
+            },
+            bounceAtEdgeOfSpirite: function(spt1, spt2){
+                spt1.bounceWithinRect(spt2);
             }
         },
         stage: {

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -911,9 +911,6 @@
             stopAtEdge: function stopAtEdge(spt){
                 spt.stayWithinRect(canvasRect());
             },
-            bounceAtEdgeOfSpirite: function bounceAtEdgeOfSpirite(spt1, spt2){
-                spt1.bounceWithinRect(spt2);
-            },
             checkForCollision: function checkForCollision(spt1, spt2){
                 return spt1.checkForCollision(spt2);
             }

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -753,6 +753,7 @@
                 });
             },
             rectangle: function(pt, width, height, orientation){
+                //debugger;
                 return new util.Shape(function(ctx){
                     ctx.beginPath();
                     if(orientation == "center"){
@@ -769,6 +770,10 @@
                         ctx.lineTo(pt.x, pt.y + height);
                         ctx.lineTo(pt.x, pt.y);
                     }
+                    this.x = pt.x;
+                    this.y = pt.y;
+                    this.width = width;
+                    this.height = height;
                 });
             },
             ellipse: function(pt, rad1, rad2, rot){
@@ -849,13 +854,13 @@
         },
 
         sprite: {
-            create: function(imgShapeOrSprite){
+            create: function create(imgShapeOrSprite){
                 return new util.Sprite(imgShapeOrSprite);
             },
-            accelerate: function(spt, speed){
+            accelerate: function accelerate(spt, speed){
                 spt.accelerate(speed);
             },
-            setVelocity: function(spt, vec){
+            setVelocity: function setVelocity(spt, vec){
                 spt.setVelocity(vec);
             },
             getVelocity: function spriteGetVelocityExpr(spt){
@@ -864,47 +869,50 @@
             getSpeed: function spriteGetSpeedExpr(spt){
                 return spt.velocity.magnitude();
             },
-            getXvel: function(spt){
+            getXvel: function getXvel(spt){
                 return spt.getXvel();
             },
-            getYvel: function(spt){
+            getYvel: function getYvel(spt){
                 return spt.getYvel();
             },
-            getXpos: function(spt){
+            getXpos: function getXpos(spt){
                 return spt.getXpos();
             },
-            getYpos: function(spt){
+            getYpos: function getYpos(spt){
                 return spt.getYpos();
             },
-            rotate: function(spt, angle){
+            rotate: function rotate(spt, angle){
                 spt.rotate(angle);
             },
-            rotateTo: function(spt, angle){
+            rotateTo: function rotateTo(spt, angle){
                 spt.rotateTo(angle);
             },
-            move: function(spt){
+            move: function move(spt){
                 spt.move();
             },
-            moveTo: function(spt, pt){
+            moveTo: function moveTo(spt, pt){
                 spt.moveTo(pt);
             },
-            draw: function(spt){
+            draw: function draw(spt){
                 spt.draw(getContext());
             },
-            applyForce: function(spt, vec){
+            applyForce: function applyForce(spt, vec){
                 spt.applyForce(vec);
             },
-            bounceAtEdge: function(spt){
+            bounceAtEdge: function bounceAtEdge(spt){
                 spt.bounceWithinRect(canvasRect());
             },
-            wrapAtEdge: function(spt){
+            wrapAtEdge: function wrapAtEdge(spt){
                 spt.wrapAroundRect(canvasRect());
             },
-            stopAtEdge: function(spt){
+            stopAtEdge: function stopAtEdge(spt){
                 spt.stayWithinRect(canvasRect());
             },
-            bounceAtEdgeOfSpirite: function(spt1, spt2){
+            bounceAtEdgeOfSpirite: function bounceAtEdgeOfSpirite(spt1, spt2){
                 spt1.bounceWithinRect(spt2);
+            },
+            checkForCollision: function checkForCollision(spt1, spt2){
+                return spt1.checkForCollision(spt2);
             }
         },
         stage: {

--- a/js/util.js
+++ b/js/util.js
@@ -269,13 +269,10 @@
         if (type(pathArrayOrFunction) === 'function'){
             this._draw = pathArrayOrFunction;
         }else if (type(pathArrayOrFunction) === 'array'){
-            var len = pathArrayOrFunction.length;
-            var i = 0;
-            while (i<len){
+            for(int i =0; i < pathArrayOrFunction.length; i++){
                 if(!(pathArrayOrFunction[i] instanceof Path)){
                     throw new Error('Only paths may be added to a Shape, ' + pathArrayOrFunction[i] + " is not.");
                 }
-                i = i+1;
             }
             this.pathArray = pathArrayOrFunction;
         }else{
@@ -898,6 +895,7 @@
     function Sprite(drawable){
         // drawable can be a shape function, an image, or text
         // wrap image with a function, make sure all are centred on 0,0
+        debugger;
         this.drawable = drawable || defaultDrawable;
         this.position = new Vector(0,0);
         this.facing = new Vector(1,0);
@@ -957,6 +955,7 @@
     }
 
     Sprite.prototype.bounceWithinRect = function(r){
+        debugger;
         if (this.position.x > (r.x + r.width) && this.velocity.x > 0){
             this.velocity = new Vector(this.velocity.x *= -1, this.velocity.y);
         }else if (this.position.x < r.x && this.velocity.x < 0){

--- a/js/util.js
+++ b/js/util.js
@@ -266,10 +266,11 @@
 
     //Shape
     function Shape(pathArrayOrFunction){
+        //debugger;
         if (type(pathArrayOrFunction) === 'function'){
             this._draw = pathArrayOrFunction;
         }else if (type(pathArrayOrFunction) === 'array'){
-            for(int i =0; i < pathArrayOrFunction.length; i++){
+            for(var i =0; i < pathArrayOrFunction.length; i++){
                 if(!(pathArrayOrFunction[i] instanceof Path)){
                     throw new Error('Only paths may be added to a Shape, ' + pathArrayOrFunction[i] + " is not.");
                 }
@@ -280,6 +281,7 @@
         }
     }
     Shape.prototype.draw = function(ctx){
+        //debugger;
         if (this.pathArray){
             ctx.beginPath();
             var i;
@@ -895,7 +897,7 @@
     function Sprite(drawable){
         // drawable can be a shape function, an image, or text
         // wrap image with a function, make sure all are centred on 0,0
-        debugger;
+        //debugger;
         this.drawable = drawable || defaultDrawable;
         this.position = new Vector(0,0);
         this.facing = new Vector(1,0);
@@ -954,7 +956,20 @@
         ctx.setTransform(1,0,0,1,0,0); // back to identity matrix
     }
 
-    Sprite.prototype.bounceWithinRect = function(r){
+    Sprite.prototype.bounceWithinRect = function bounceWithinRect(r){ // alpha
+        if (this.position.x > (r.x + r.width) && this.velocity.x > 0){
+            this.velocity = new Vector(this.velocity.x *= -1, this.velocity.y);
+        }else if (this.position.x < r.x && this.velocity.x < 0){
+            this.velocity = new Vector(this.velocity.x *= -1, this.velocity.y);
+        }
+        if (this.position.y > (r.y + r.height) && this.velocity.y > 0){
+            this.velocity = new Vector(this.velocity.x, this.velocity.y *= -1);
+        }else if (this.position.y < r.y && this.velocity.y < 0){
+            this.velocity = new Vector(this.velocity.x, this.velocity.y *= -1);
+        }
+    }
+
+    Sprite.prototype.checkForCollision = function checkForCollision(r){ // alpha
         debugger;
         if (this.position.x > (r.x + r.width) && this.velocity.x > 0){
             this.velocity = new Vector(this.velocity.x *= -1, this.velocity.y);

--- a/js/util.js
+++ b/js/util.js
@@ -991,7 +991,7 @@
     }
 
     function checkForCollisionRectangleAndCircle(rectangle, circle){
-        // Solution came from http://stackoverflow.com/questions/401847/circle-rectangle-collision-detection-intersection
+        // Solution came from `http://stackoverflow.com/questions/401847/circle-rectangle-collision-detection-intersection`
 
         var center_x;
         var center_y;

--- a/js/util.js
+++ b/js/util.js
@@ -969,12 +969,36 @@
         }
     }
 
-    Sprite.prototype.checkForCollision = function checkForCollision(r){
+    Sprite.prototype.checkForCollision = function checkForCollision(other){
 
-        return this.position.x < r.drawable.x + r.drawable.width &&
-                this.position.x + this.drawable.width > r.drawable.x &&
-                this.position.y < r.drawable.y + r.drawable.height &&
-                this.drawable.height + this.position.y > r.drawable.y
+        var this_x;
+        var this_y;
+        var other_x;
+        var other_y;
+
+        if(this.drawable.centered){
+            this_x = this.position.x - this.drawable.width/2;
+            this_y = this.position.y - this.drawable.height/2;
+        }
+        else{
+            this_x = this.position.x;
+            this_y = this.position.y;
+        }
+
+
+        if(other.drawable.centered){
+            other_x = other.position.x - other.drawable.width/2;
+            other_y = other.position.y - other.drawable.height/2;
+        }
+        else{
+            other_x = other.position.x;
+            other_y = other.position.y;
+        }
+
+        return this_x < other_x + other.drawable.width &&
+                this_x + this.drawable.width > other_x &&
+                this_y < other_y + other.drawable.height &&
+                this.drawable.height + this_y > other.position.y
     }
 
     Sprite.prototype.wrapAroundRect = function(r){

--- a/js/util.js
+++ b/js/util.js
@@ -971,18 +971,44 @@
 
     Sprite.prototype.checkForCollision = function checkForCollision(other){
 
+        var collision = false;
+
+        if(this.drawable.width && other.drawable.width){
+            collision = checkForCollisionTwoRectangles(this, other);
+        }
+        else if(this.drawable.radius && other.drawable.radius){
+            collision = checkForCollisionTwoCircles(this, other);
+        }
+
+        return collision;
+
+    }
+
+    function checkForCollisionTwoCircles(this_, other){
+
+        var diff_x = this_.position.x - other.position.x;
+        var diff_y = this_.position.y - other.position.y;
+
+        var distance = Math.sqrt(diff_x * diff_x + diff_y * diff_y);
+
+        return distance < this_.drawable.radius + other.drawable.radius;
+
+    }
+
+    function checkForCollisionTwoRectangles(this_, other){
+
         var this_x;
         var this_y;
         var other_x;
         var other_y;
 
         if(this.drawable.centered){
-            this_x = this.position.x - this.drawable.width/2;
-            this_y = this.position.y - this.drawable.height/2;
+            this_x = this_.position.x - this_.drawable.width/2;
+            this_y = this_.position.y - this_.drawable.height/2;
         }
         else{
-            this_x = this.position.x;
-            this_y = this.position.y;
+            this_x = this_.position.x;
+            this_y = this_.position.y;
         }
 
 
@@ -996,9 +1022,9 @@
         }
 
         return this_x < other_x + other.drawable.width &&
-                this_x + this.drawable.width > other_x &&
+                this_x + this_.drawable.width > other_x &&
                 this_y < other_y + other.drawable.height &&
-                this.drawable.height + this_y > other.position.y
+                this_.drawable.height + this_y > other_y;
     }
 
     Sprite.prototype.wrapAroundRect = function(r){

--- a/js/util.js
+++ b/js/util.js
@@ -970,17 +970,10 @@
     }
 
     Sprite.prototype.checkForCollision = function checkForCollision(r){ // alpha
-        debugger;
-        if (this.position.x > (r.x + r.width) && this.velocity.x > 0){
-            this.velocity = new Vector(this.velocity.x *= -1, this.velocity.y);
-        }else if (this.position.x < r.x && this.velocity.x < 0){
-            this.velocity = new Vector(this.velocity.x *= -1, this.velocity.y);
-        }
-        if (this.position.y > (r.y + r.height) && this.velocity.y > 0){
-            this.velocity = new Vector(this.velocity.x, this.velocity.y *= -1);
-        }else if (this.position.y < r.y && this.velocity.y < 0){
-            this.velocity = new Vector(this.velocity.x, this.velocity.y *= -1);
-        }
+        return this.position.x < r.drawable.x + r.drawable.width &&
+                this.position.x + this.drawable.width > r.drawable.x &&
+                this.position.y < r.drawable.y + r.drawable.height &&
+                this.drawable.height + this.position.y > r.drawable.y
     }
 
     Sprite.prototype.wrapAroundRect = function(r){

--- a/js/util.js
+++ b/js/util.js
@@ -266,7 +266,6 @@
 
     //Shape
     function Shape(pathArrayOrFunction){
-        //debugger;
         if (type(pathArrayOrFunction) === 'function'){
             this._draw = pathArrayOrFunction;
         }else if (type(pathArrayOrFunction) === 'array'){
@@ -281,7 +280,6 @@
         }
     }
     Shape.prototype.draw = function(ctx){
-        //debugger;
         if (this.pathArray){
             ctx.beginPath();
             var i;
@@ -897,7 +895,6 @@
     function Sprite(drawable){
         // drawable can be a shape function, an image, or text
         // wrap image with a function, make sure all are centred on 0,0
-        //debugger;
         this.drawable = drawable || defaultDrawable;
         this.position = new Vector(0,0);
         this.facing = new Vector(1,0);

--- a/js/util.js
+++ b/js/util.js
@@ -956,7 +956,7 @@
         ctx.setTransform(1,0,0,1,0,0); // back to identity matrix
     }
 
-    Sprite.prototype.bounceWithinRect = function bounceWithinRect(r){ // alpha
+    Sprite.prototype.bounceWithinRect = function bounceWithinRect(r){
         if (this.position.x > (r.x + r.width) && this.velocity.x > 0){
             this.velocity = new Vector(this.velocity.x *= -1, this.velocity.y);
         }else if (this.position.x < r.x && this.velocity.x < 0){
@@ -969,7 +969,8 @@
         }
     }
 
-    Sprite.prototype.checkForCollision = function checkForCollision(r){ // alpha
+    Sprite.prototype.checkForCollision = function checkForCollision(r){
+
         return this.position.x < r.drawable.x + r.drawable.width &&
                 this.position.x + this.drawable.width > r.drawable.x &&
                 this.position.y < r.drawable.y + r.drawable.height &&

--- a/js/util.js
+++ b/js/util.js
@@ -979,10 +979,62 @@
         else if(this.drawable.radius && other.drawable.radius){
             collision = checkForCollisionTwoCircles(this, other);
         }
+        else if(this.drawable.radius && other.drawable.width){
+            collision = checkForCollisionRectangleAndCircle(other, this);
+        }
+        else if(this.drawable.width && other.drawable.radius){
+            collision = checkForCollisionRectangleAndCircle(this, other);
+        }
 
         return collision;
 
     }
+
+    function checkForCollisionRectangleAndCircle(rectangle, circle){
+        // Solution came from http://stackoverflow.com/questions/401847/circle-rectangle-collision-detection-intersection
+
+        var center_x;
+        var center_y;
+
+        if(rectangle.drawable.centered){
+            center_x = rectangle.position.x;
+            center_y = rectangle.position.y;
+        }
+        else{
+            center_x = rectangle.position.x + rectangle.drawable.width/2;
+            center_y = rectangle.position.y + rectangle.drawable.height/2;
+        }
+
+        var distance_x = Math.abs(circle.position.x - center_x);
+        var distance_y = Math.abs(circle.position.y - center_y);
+
+        var collision = false;
+
+
+        if(distance_x > rectangle.drawable.width/2 + circle.drawable.radius){
+            collision = false;
+        }
+        else if(distance_y > rectangle.drawable.height/2 + circle.drawable.radius){
+            collision = false;
+        }
+        else if(distance_x <= rectangle.drawable.width/2){
+            collision = true;
+        }
+        else if(distance_y <= rectangle.drawable.height/2){
+            collision = true;
+        }
+        else{
+            var corner_distance = Math.pow(distance_x - rectangle.width/2, 2) +
+                                Math.pow(distance_y - rectangle.height/2, 2);
+
+            collision = corner_distance <= Math.pow(circle.drawable.radius, 2);
+
+        }
+
+        return collision;
+
+    }
+
 
     function checkForCollisionTwoCircles(this_, other){
 
@@ -1002,7 +1054,7 @@
         var other_x;
         var other_y;
 
-        if(this.drawable.centered){
+        if(this_.drawable.centered){
             this_x = this_.position.x - this_.drawable.width/2;
             this_y = this_.position.y - this_.drawable.height/2;
         }

--- a/playground.html
+++ b/playground.html
@@ -215,10 +215,6 @@
                 <wb-step ns="sprite" fn="stopAtEdge">
                     <wb-value type="sprite">stop at edge</wb-value>
                 </wb-step>
-                <wb-step ns="sprite" fn="bounceAtEdgeOfSpirite">
-                    <wb-value type="sprite">bounce at edge of spirte</wb-value>
-                    <wb-value type="sprite"></wb-value>
-                </wb-step>
                 <wb-expression type="boolean" ns="sprite" fn="checkForCollision">
                     <wb-value type="sprite">is collision</wb-value>
                     <wb-value type="sprite"></wb-value>

--- a/playground.html
+++ b/playground.html
@@ -215,6 +215,9 @@
                 <wb-step ns="sprite" fn="stopAtEdge">
                     <wb-value type="sprite">stop at edge</wb-value>
                 </wb-step>
+                <wb-step ns="sprite" fn="bounceAtEdgeOfSpirite">
+                    <wb-value type="sprite">bounce at edge of spirte</wb-value>
+                </wb-step>
             </wb-accordion>
             <wb-accordion class="sound">
                 <header>

--- a/playground.html
+++ b/playground.html
@@ -217,6 +217,7 @@
                 </wb-step>
                 <wb-step ns="sprite" fn="bounceAtEdgeOfSpirite">
                     <wb-value type="sprite">bounce at edge of spirte</wb-value>
+                    <wb-value type="sprite"></wb-value>
                 </wb-step>
             </wb-accordion>
             <wb-accordion class="sound">

--- a/playground.html
+++ b/playground.html
@@ -219,6 +219,10 @@
                     <wb-value type="sprite">bounce at edge of spirte</wb-value>
                     <wb-value type="sprite"></wb-value>
                 </wb-step>
+                <wb-expression type="boolean" ns="sprite" fn="checkForCollision">
+                    <wb-value type="sprite">is collision</wb-value>
+                    <wb-value type="sprite"></wb-value>
+                </wb-expression>
             </wb-accordion>
             <wb-accordion class="sound">
                 <header>


### PR DESCRIPTION
Created a collision detection block. Currently, it will only detect collisions between square and circle sprites. The collision also assumes that the squares and rectangles are drawn at location 0,0 and it uses the sprites location to determine collision. The collision also doesn't account for rectangles that have their angle changed. 

This is not perfect, but I think it's good start.

There's also an example you can try out called `simple pong` to show how to use it.

Issue reference https://github.com/waterbearlang/waterbear/issues/1207