### PR TITLE
Add code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ waterbear.bbprojectd
 .DS_Store
 node_modules
 out/
+coverage/

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,8 +15,20 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      { pattern: 'js/util.js', watched: false },
+      { pattern: 'js/event.js', watched: false },
+      'js/dom.js',
+      //'js/block.js',
+      'js/file.js',
+      'js/queryparams.js',
+      'js/undo.js',
+      //'js/app*.js',
+      //'js/widget.js',
       'js/runtime.js',
-      'test/runtime.html'
+      'test/test-helpers.js',
+      'test/sinon-1.12.2.js',
+      'test/runtime.js',
+      //'test/all-blocks-have-functions.js'
     ],
 
 
@@ -28,7 +40,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-        'js/runtime.js': ['coverage']
+        'js/*.js': ['coverage']
     },
 
 
@@ -52,7 +64,7 @@ module.exports = function(config) {
 
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
+    autoWatch: false,
 
 
     // start these browsers

--- a/my.conf.js
+++ b/my.conf.js
@@ -1,0 +1,67 @@
+// Karma configuration
+// Generated on Thu Oct 15 2015 22:14:00 GMT-0400 (EDT)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['qunit'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'js/runtime.js',
+      'test/runtime.html'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+        'js/runtime.js': ['coverage']
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress', 'coverage'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true
+  })
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "karma-qunit": "^0.1.5",
     "parse5": "^1.5.0",
     "phantomjs": "^1.9.18",
-    "qunitjs": "^1.19.0",
+    "qunitjs": "^1.19.0"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -27,11 +27,9 @@
     "karma-coverage": "^0.5.2",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-qunit": "^0.1.5",
-    "karma-requirejs": "^0.2.2",
     "parse5": "^1.5.0",
     "phantomjs": "^1.9.18",
     "qunitjs": "^1.19.0",
-    "requirejs": "^2.1.20"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start my.conf.js"
+    "test": "./node_modules/karma/bin/karma start karma.conf.js"
   },
   "repository": {
     "type": "git",
@@ -27,10 +27,11 @@
     "karma-coverage": "^0.5.2",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-qunit": "^0.1.5",
-    "node-qunit-phantomjs": "^1.2.0",
+    "karma-requirejs": "^0.2.2",
     "parse5": "^1.5.0",
     "phantomjs": "^1.9.18",
-    "qunitjs": "^1.19.0"
+    "qunitjs": "^1.19.0",
+    "requirejs": "^2.1.20"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./run_tests.sh"
+    "test": "./node_modules/karma/bin/karma start my.conf.js"
   },
   "repository": {
     "type": "git",
@@ -23,8 +23,14 @@
   "homepage": "https//waterbearlang.com/",
   "devDependencies": {
     "istanbul": "^0.3.21",
+    "karma": "^0.13.11",
+    "karma-coverage": "^0.5.2",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-qunit": "^0.1.5",
     "node-qunit-phantomjs": "^1.2.0",
-    "parse5": "^1.5.0"
+    "parse5": "^1.5.0",
+    "phantomjs": "^1.9.18",
+    "qunitjs": "^1.19.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Not ready to merge, just have a few questions/issues.

Since run_tests.sh is giving test/runtime.html as a parameter, is that what I should include as the test script in my.conf.js? Or should it be test/runtime.js? 

```    
// list of files / patterns to load in the browser
    files: [
      'js/runtime.js',
      'test/runtime.html'
    ],
```

With this configuration I get the following error when I run ```npm test```:

```
Alex-MacLeans-MacBook-Pro:waterbear alexmaclean$ npm test

> waterbear@0.8.0 test /Users/alexmaclean/Development/waterbear
> ./node_modules/karma/bin/karma start my.conf.js

15 10 2015 23:18:04.732:INFO [karma]: Karma v0.13.11 server started at http://localhost:9876/
15 10 2015 23:18:04.744:INFO [launcher]: Starting browser PhantomJS
15 10 2015 23:18:06.803:INFO [PhantomJS 1.9.8 (Mac OS X 0.0.0)]: Connected on socket 8HZMnpN7LPauoxnXAAAA with id 88181536
PhantomJS 1.9.8 (Mac OS X 0.0.0) ERROR
  TypeError: 'undefined' is not a function (evaluating 'Event.on')
  at /Users/alexmaclean/Development/waterbear/js/runtime.js:9


npm ERR! Test failed.  See above for more details.
```

Not sure what's triggering the error :confused: .