### PR TITLE
Audio samples can be stopped before they finish (with the stop button or the pause block)

### DIFF
--- a/js/runtime.js
+++ b/js/runtime.js
@@ -81,6 +81,12 @@
         clearPerFrameHandlers();
         /* Clear all runtime event handlers. */
         Event.off(null, 'runtime:*');
+        for (var prop in assets.sounds){
+            if (!assets.sounds.hasOwnProperty(prop)){
+                continue;
+            }
+            assets.sounds[prop].pause();
+        }
     }
 
     // utility for iterating over child blocks
@@ -881,7 +887,9 @@
                 sound.volume = volume;
             },
             pause: function(sound){
-                sound.pause();
+                if (assets.sounds[sound.name]){
+                    assets.sounds[sound.name].pause();
+                }
             },
             playFrom: function(sound, time){
                 sound.playFrom(time);


### PR DESCRIPTION
Or if they are in a loop.

I really don't think there is anything that can be called on a sound effect to stop or pause it before it finishes.

I modified the pause button too so it doesn't cause an exception if someone tries to use it on a sound effect.

Fixes #1184 