### PR TITLE
Preserve order from HTML in custom elements

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -231,7 +231,6 @@ BlockProto.attachedCallback = function blockAttached(){
     if (parent){
         setDefaultByTag(parent, 'wb-contains').appendChild(this);
     }
-    console.log('attached callback, children: %s', [].slice.call(this.children).map(function(child){ return child.localName; }).join(', '));
 };
 
 BlockProto.header = function blockHeader(){


### PR DESCRIPTION
There was an ordering problem between `wb-values` and `wb-row` when we stash them in the block header. Apparently processing siblings in order is not actually required by the Custom Element spec. Anyway, this uses less of the Custom Element API and seems to work across browsers now.