### PR TITLE
Added 4 digit input restriction for Date blocks

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -887,6 +887,12 @@ ValueProto.createdCallback = function valueCreated(){
             if (this.hasAttribute('max')){
                 input.setAttribute('max', this.getAttribute('max'));
             }
+            if (this.hasAttribute('oninput')){
+                input.setAttribute('oninput', this.getAttribute('oninput'));
+                // set the callback only on the actual input element
+                // and remove from parent to prevent double calls
+                this.removeAttribute('oninput');
+            }
             this.appendChild(input);
             input.value = value;
             break;

--- a/js/runtime.js
+++ b/js/runtime.js
@@ -1474,7 +1474,12 @@
         },
         date: {
             create: function (year, month, day) {
-                return new Date(year, month-1, day);
+                var today = new Date();
+                // by using fullYear, an input of 1 results in year 1
+                // and not 1901 which happens when using constructor
+                today.setFullYear(year, month - 1, day);
+                today.setHours(0, 0, 0, 0);
+                return today;
             },
             now: function () {
                 var today = new Date();
@@ -1516,7 +1521,18 @@
             getYear: function(date){
                 return date.getFullYear();
             },
+            validateYear: function(inputElement){
+                // we manually check for negative numbers because leaving a
+                // min value of 0 will have the erroneous effect of leaving
+                // a leading 0 that can't be deleted when deleting all
+                // characters from the field
+                if (inputElement.value < 0)
+                    inputElement.value = 0;
 
+                // simulate a maxlength of 4 by slicing the input
+                if (inputElement.value.length > 4)
+                    inputElement.value = inputElement.value.slice(0, -1);
+            }
         }
     };
 

--- a/playground.html
+++ b/playground.html
@@ -366,7 +366,7 @@
                 <p>Dates are used to represent a date and to do basic calculations.</p>
                 <wb-expression type="date" ns="date" fn="now">today</wb-expression>
                 <wb-expression type="date" ns="date" fn="create">
-                    <wb-value type="number" min="0">yyyy</wb-value>
+                    <wb-value type="number" oninput="runtime.date.validateYear(this)">yyyy</wb-value>
                     <wb-value type="number">mm</wb-value>
                     <wb-value type="number">dd</wb-value>
                 </wb-expression>

--- a/test/runtime.js
+++ b/test/runtime.js
@@ -1714,7 +1714,8 @@ QUnit.test('create',function(assert){
     var date6 = new Date("Nov 01 1999");
 
     var date7 = date.create(0, 01, 01);
-    var date8 = new Date("Jan 01 1900");
+    // forced new format to have year 0 instead of 1900
+    var date8 = new Date("0000-01-01");
 
     assert.ok(date1.valueOf() === date2.valueOf());
     assert.ok(date3.valueOf() === date4.valueOf());


### PR DESCRIPTION
Added an 'oninput' callback on the Date block year input which points to the 'validateYear' function on the runtime.

Restriction to 4 characters is done by checking the year length and setting the value to the sliced 4 digit value if the limit is reached.

Removed the 'min=0' attribute and added a manual check because when editing a field and reaching the maximum value, a leading 0 that cannot be deleted is left on the field. e.g. if trying to input 99999 the field becomes 0 and so only 3 other characters can be set.

Tested on Chrome 47.0.2526.106 m, Firefox 43.0.2 

P.S. Apologies for breaking the build the first time, I hadn't run the tests locally...
