### PR TITLE
937 tabs slots

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -207,16 +207,16 @@ wb-workspace > wb-contains {
     padding-bottom: 16px;
 }
 
-wb-contains:empty::before {
+/* wb-contains:empty::before {
     display: block;
     content: "Drag Blocks Here";
-    /* FIXME: Localization problem, all localizable content should be in HTML text */
+    // FIXME: Localization problem, all localizable content should be in HTML text 
     width: 100%;
     height: 20px;
     text-align: center;
     margin-top: auto;
     margin-bottom: auto;
-}
+} */
 
 
 /* Accordion Colors and Icons */

--- a/css/block.css
+++ b/css/block.css
@@ -73,12 +73,21 @@ wb-step > svg.tab, wb-context > svg.tab{
      fill: white;
  }
  
- wb-contains > svg.slot{
+ /* wb-contains > svg.slot{
      position: absolute;
      display: block;
      left: 34px;
      top: -12px;
      fill: white;
+ } */
+
+ wb-contains::before{
+    content: url("../images/tab.svg");
+    position: absolute;
+    display: block;
+    left: 34px;
+    top: -12px;
+    fill: white;
  }
 
  wb-step, wb-context{
@@ -233,7 +242,7 @@ wb-context > wb-contains {
     background-color: rgba(255, 255, 255, 1.0);
     position: relative;
     margin-bottom: 0;
-    padding-top: 2px;
+    padding-top: 3px;
     padding-left: 5px;
     padding-bottom: 10px;
     border-top-left-radius: 10px;

--- a/css/block.css
+++ b/css/block.css
@@ -10,10 +10,27 @@ wb-expression {
     border-width: 2px;
     border-style: solid;
     margin: 5px 5px 2px 2px;
+    padding-left: 10px;
     float: left;
     clear: left;
     position: relative;
+    z-index: 0;
 }
+
+wb-workspace wb-context, wb-workspace wb-step{
+    margin-top: -2px;
+}
+
+wb-workspace wb-contains{
+    padding-top: 20px;
+    padding-left: 5px;
+    padding-right: 0;
+}
+
+/* header{
+    z-index: 0;
+} */
+
 
 body:not(.block-dragging) wb-step,
 body:not(.block-dragging) wb-context,
@@ -35,6 +52,61 @@ body:not(.block-dragging) wb-expression {
     cursor: -webkit-grabbing;
 }
 
+/* add a tab to steps */
+
+wb-step > svg.tab, wb-context > svg.tab{
+    position: absolute;
+    left: 25px;
+    top: -12px;
+    /* height: 12px; */
+ }
+
+ svg.slot{
+     display: none;
+ }
+
+ wb-step > svg.slot, wb-context > svg.slot{
+     position: absolute;
+     display: block;
+     left: 25px;
+     bottom: -2px;
+     fill: white;
+ }
+ 
+ wb-contains > svg.slot{
+     position: absolute;
+     display: block;
+     left: 34px;
+     top: -12px;
+     fill: white;
+ }
+
+ wb-step, wb-context{
+     padding-bottom: 14px;
+ }
+
+ wb-context > header{
+     margin-bottom: 14px;
+ }
+
+
+
+
+wb-step{
+    padding-bottom: 12px;
+    margin-top: -3px;
+}
+
+wb-context{
+    margin-top: -3px;
+}
+
+wb-context, wb-context > header{
+    padding-bottom: 15px;
+}
+
+/* end tab-related code */
+
 wb-contains.drop-target {
     background-color: #ffffe0;
 }
@@ -42,6 +114,10 @@ wb-contains.drop-target {
 wb-contains.selected-block {
     background-color: #ccffcc;
     /* not sure if selected and drop-target should be the same highlight colour? Which is least surprising? */
+}
+
+wb-workspace > wb-contains{
+    padding-top: 15px;
 }
 
 wb-value.drop-target input:first-of-type {
@@ -72,8 +148,18 @@ wb-context.dragging,
 wb-expression.dragging {
     opacity: 0.5;
     position: absolute;
+    z-index: 10;
     /* Necessary for dragging events. */
     pointer-events: none;
+}
+
+
+wb-context > wb-contains::after{
+    content: "";
+    height: 1px;
+    display: block;
+    visibility: none;
+    clear: both;
 }
 
 
@@ -146,28 +232,20 @@ wb-context > wb-contains {
     display: block;
     background-color: rgba(255, 255, 255, 1.0);
     position: relative;
-    padding-top: 7px;
-    margin-left: 10px;
     margin-bottom: 0;
-    padding-bottom: 1px;
-    overflow-x: hidden;
-    overflow-y: hidden;
+    padding-top: 2px;
+    padding-left: 5px;
+    padding-bottom: 10px;
     border-top-left-radius: 10px;
     border-bottom-left-radius: 10px;
-    border-width: 2px 0 2px 2px;
+    /* border-width: 2px 0 2px 2px;
     border-style: solid;
     border-color: inherit;
-    border-right: 0;
+    border-right: 0; */
+    border: 0;
     right: -3px;
 }
 
-wb-context > wb-contains:last-child:after {
-    content: "";
-    display: block;
-    height: 0;
-    clear: both;
-    visibility: hidden;
-}
 
 wb-context > header > wb-disclosure:after {
     content: "▼";

--- a/css/block_colors.css
+++ b/css/block_colors.css
@@ -8,12 +8,16 @@
 .block-dragging [ns="control"].drop-target.selected-block {
     background-color: hsl(0, 50%, 50%);
     border-color: hsl(0, 50%, 30%);
+    fill: hsl(0, 50%, 50%);
+    stroke: hsl(0, 50%, 30%);
 }
 
 .block-dragging [ns="control"],
 .block-dragging [ns="control"].selected-block {
     background-color: hsl(0, 50%, 75%);
     border-color: hsl(0, 50%, 60%);
+    fill: hsl(0, 50%, 75%);
+    stroke: hsl(0, 50%, 60%);
 }
 
 [ns="sprite"],
@@ -21,12 +25,16 @@
 .block-dragging [ns="sprite"].drop-target.selected-block {
     background-color: hsl(105, 50%, 50%);
     border-color: hsl(105, 50%, 30%);
+    fill: hsl(105, 50%, 50%);
+    stroke: hsl(105, 50%, 30%);
 }
 
 .block-dragging [ns="sprite"],
 .block-dragging [ns="sprite"].selected-block {
     background-color: hsl(105, 50%, 75%);
     border-color: hsl(105, 50%, 60%);
+    fill: hsl(105, 50%, 75%);
+    stroke: hsl(105, 50%, 60%);
 }
 
 [ns="music"],
@@ -34,12 +42,16 @@
 .block-dragging [ns="music"].drop-target.selected-block {
     background-color: hsl(210, 50%, 50%);
     border-color: hsl(210, 50%, 30%);
+    fill: hsl(210, 50%, 50%);
+    stroke: hsl(210, 50%, 30%);
 }
 
 .block-dragging [ns="music"],
 .block-dragging [ns="music"].selected-block {
     background-color: hsl(210, 50%, 75%);
     border-color: hsl(210, 50%, 60%);
+    fill: hsl(210, 50%, 75%);
+    stroke: hsl(210, 50%, 60%);
 }
 
 [ns="sound"],
@@ -47,12 +59,16 @@
 .block-dragging [ns="sound"].drop-target.selected-block {
     background-color: hsl(315, 50%, 50%);
     border-color: hsl(315, 50%, 30%);
+    fill: hsl(315, 50%, 50%);
+    stroke: hsl(315, 50%, 30%);
 }
 
 .block-dragging [ns="sound"],
 .block-dragging [ns="sound"].selected-block {
     background-color: hsl(315, 50%, 75%);
     border-color: hsl(315, 50%, 60%);
+    fill: hsl(315, 50%, 75%);
+    stroke: hsl(315, 50%, 60%);
 }
 
 [ns="array"],
@@ -60,12 +76,16 @@
 .block-dragging [ns="array"].drop-target.selected-block {
     background-color: hsl(60, 50%, 50%);
     border-color: hsl(60, 50%, 30%);
+    fill: hsl(60, 50%, 50%);
+    stroke: hsl(60, 50%, 30%);
 }
 
 .block-dragging [ns="array"],
 .block-dragging [ns="array"].selected-block {
     background-color: hsl(60, 50%, 75%);
     border-color: hsl(60, 50%, 60%);
+    fill: hsl(60, 50%, 75%);
+    stroke: hsl(60, 50%, 60%);
 }
 
 [ns="boolean"],
@@ -73,12 +93,16 @@
 .block-dragging [ns="boolean"].drop-target.selected-block {
     background-color: hsl(165, 50%, 50%);
     border-color: hsl(165, 50%, 30%);
+    fill: hsl(165, 50%, 50%);
+    stroke: hsl(165, 50%, 30%);
 }
 
 .block-dragging [ns="boolean"],
 .block-dragging [ns="boolean"].selected-block {
     background-color: hsl(165, 50%, 75%);
     border-color: hsl(165, 50%, 60%);
+    fill: hsl(165, 50%, 75%);
+    stroke: hsl(165, 50%, 60%);
 }
 
 [ns="stage"],
@@ -86,12 +110,16 @@
 .block-dragging [ns="stage"].drop-target.selected-block {
     background-color: hsl(270, 50%, 50%);
     border-color: hsl(270, 50%, 30%);
+    fill: hsl(270, 50%, 50%);
+    stroke: hsl(270, 50%, 30%);
 }
 
 .block-dragging [ns="stage"],
 .block-dragging [ns="stage"].selected-block {
     background-color: hsl(270, 50%, 75%);
     border-color: hsl(270, 50%, 60%);
+    fill: hsl(270, 50%, 75%);
+    stroke: hsl(270, 50%, 60%);
 }
 
 [ns="color"],
@@ -99,12 +127,16 @@
 .block-dragging [ns="color"].drop-target.selected-block {
     background-color: hsl(15, 50%, 50%);
     border-color: hsl(15, 50%, 30%);
+    fill: hsl(15, 50%, 50%);
+    stroke: hsl(15, 50%, 30%);
 }
 
 .block-dragging [ns="color"],
 .block-dragging [ns="color"].selected-block {
     background-color: hsl(15, 50%, 75%);
     border-color: hsl(15, 50%, 60%);
+    fill: hsl(15, 50%, 75%);
+    stroke: hsl(15, 50%, 60%);
 }
 
 [ns="image"],
@@ -112,25 +144,33 @@
 .block-dragging [ns="image"].drop-target.selected-block {
     background-color: hsl(120, 50%, 50%);
     border-color: hsl(120, 50%, 30%);
+    fill: hsl(120, 50%, 50%);
+    stroke: hsl(120, 50%, 30%);
 }
 
 .block-dragging [ns="image"],
 .block-dragging [ns="image"].selected-block {
     background-color: hsl(120, 50%, 75%);
     border-color: hsl(120, 50%, 60%);
+    fill: hsl(120, 50%, 75%);
+    stroke: hsl(120, 50%, 60%);
 }
 
 [ns="math"],
 .block-dragging [ns="math"].drop-target,
-.block-dragging [ns="math"].drop-target.selected-block {
+.block-dragging [ns="math"].drop-target.selected-block{
     background-color: hsl(225, 50%, 50%);
     border-color: hsl(225, 50%, 30%);
+    fill: hsl(225, 50%, 50%);
+    stroke: hsl(225, 50%, 30%);
 }
 
 .block-dragging [ns="math"],
 .block-dragging [ns="math"].selected-block {
     background-color: hsl(225, 50%, 75%);
     border-color: hsl(225, 50%, 60%);
+    fill: hsl(225, 50%, 75%);
+    stroke: hsl(225, 50%, 60%);
 }
 
 [ns="random"],
@@ -138,12 +178,16 @@
 .block-dragging [ns="random"].drop-target.selected-block {
     background-color: hsl(330, 50%, 50%);
     border-color: hsl(330, 50%, 30%);
+    fill: hsl(330, 50%, 50%);
+    stroke: hsl(330, 50%, 30%);
 }
 
 .block-dragging [ns="random"],
 .block-dragging [ns="random"].selected-block {
     background-color: hsl(330, 50%, 75%);
     border-color: hsl(330, 50%, 60%);
+    fill: hsl(330, 50%, 75%);
+    stroke: hsl(330, 50%, 60%);
 }
 
 [ns="vector"],
@@ -151,12 +195,16 @@
 .block-dragging [ns="vector"].drop-target.selected-block {
     background-color: hsl(75, 50%, 50%);
     border-color: hsl(75, 50%, 30%);
+    fill: hsl(75, 50%, 50%);
+    stroke: hsl(75, 50%, 30%);
 }
 
 .block-dragging [ns="vector"],
 .block-dragging [ns="vector"].selected-block {
     background-color: hsl(75, 50%, 75%);
     border-color: hsl(75, 50%, 60%);
+    fill: hsl(75, 50%, 75%);
+    stroke: hsl(75, 50%, 60%);
 }
 
 [ns="object"],
@@ -164,12 +212,16 @@
 .block-dragging [ns="object"].drop-target.selected-block {
     background-color: hsl(180, 50%, 50%);
     border-color: hsl(180, 50%, 30%);
+    fill: hsl(180, 50%, 50%);
+    stroke: hsl(180, 50%, 30%);
 }
 
 .block-dragging [ns="object"],
 .block-dragging [ns="object"].selected-block {
     background-color: hsl(180, 50%, 75%);
     border-color: hsl(180, 50%, 60%);
+    fill: hsl(180, 50%, 75%);
+    stroke: hsl(180, 50%, 60%);
 }
 
 [ns="string"],
@@ -177,38 +229,50 @@
 .block-dragging [ns="string"].drop-target.selected-block {
     background-color: hsl(285, 50%, 50%);
     border-color: hsl(285, 50%, 30%);
+    fill: hsl(285, 50%, 50%);
+    stroke: hsl(285, 50%, 30%);
 }
 
 .block-dragging [ns="string"],
 .block-dragging [ns="string"].selected-block {
     background-color: hsl(285, 50%, 75%);
     border-color: hsl(285, 50%, 60%);
+    fill: hsl(285, 50%, 75%);
+    stroke: hsl(285, 50%, 60%);
 }
 
 [ns="path"],
 .block-dragging [ns="path"].drop-target,
-.block-dragging [ns="path"].drop-target.selected-block {
+.block-dragging [ns="path"].drop-target.selected-block{
     background-color: hsl(30, 50%, 50%);
     border-color: hsl(30, 50%, 30%);
+    fill: hsl(30, 50%, 50%);
+    stroke: hsl(30, 50%, 30%);
 }
 
 .block-dragging [ns="path"],
 .block-dragging [ns="path"].selected-block {
     background-color: hsl(30, 50%, 75%);
     border-color: hsl(30, 50%, 60%);
+    background-fill: hsl(30, 50%, 75%);
+    border-stroke: hsl(30, 50%, 60%);
 }
 
 [ns="rect"],
 .block-dragging [ns="rect"].drop-target,
-.block-dragging [ns="rect"].drop-target.selected-block {
+.block-dragging [ns="rect"].drop-target.selected-block{
     background-color: hsl(240, 50%, 50%);
     border-color: hsl(240, 50%, 30%);
+    fill: hsl(240, 50%, 50%);
+    stroke: hsl(240, 50%, 30%);
 }
 
 .block-dragging [ns="rect"],
 .block-dragging [ns="rect"].selected-block {
     background-color: hsl(240, 50%, 75%);
     border-color: hsl(240, 50%, 60%);
+    fill: hsl(240, 50%, 75%);
+    stroke: hsl(240, 50%, 60%);
 }
 
 [ns="input"],
@@ -216,12 +280,16 @@
 .block-dragging [ns="input"].drop-target.selected-block {
     background-color: hsl(345, 50%, 50%);
     border-color: hsl(345, 50%, 30%);
+    fill: hsl(345, 50%, 50%);
+    stroke: hsl(345, 50%, 30%);
 }
 
 .block-dragging [ns="input"],
 .block-dragging [ns="input"].selected-block {
     background-color: hsl(345, 50%, 75%);
     border-color: hsl(345, 50%, 60%);
+    fill: hsl(345, 50%, 75%);
+    stroke: hsl(345, 50%, 60%);
 }
 
 [ns="motion"],
@@ -229,12 +297,16 @@
 .block-dragging [ns="motion"].drop-target.selected-block {
     background-color: hsl(90, 50%, 50%);
     border-color: hsl(90, 50%, 30%);
+    fill: hsl(90, 50%, 50%);
+    stroke: hsl(90, 50%, 30%);
 }
 
 .block-dragging [ns="motion"],
 .block-dragging [ns="motion"].selected-block {
     background-color: hsl(90, 50%, 75%);
     border-color: hsl(90, 50%, 60%);
+    fill: hsl(90, 50%, 75%);
+    stroke: hsl(90, 50%, 60%);
 }
 
 [ns="shape"],
@@ -242,12 +314,16 @@
 .block-dragging [ns="shape"].drop-target.selected-block {
     background-color: hsl(195, 50%, 50%);
     border-color: hsl(195, 50%, 30%);
+    fill: hsl(195, 50%, 50%);
+    stroke: hsl(195, 50%, 30%);
 }
 
 .block-dragging [ns="shape"],
 .block-dragging [ns="shape"].selected-block {
     background-color: hsl(195, 50%, 75%);
     border-color: hsl(195, 50%, 60%);
+    fill: hsl(195, 50%, 75%);
+    stroke: hsl(195, 50%, 60%);
 }
 
 [ns="geolocation"],
@@ -255,38 +331,50 @@
 .block-dragging [ns="geolocation"].drop-target.selected-block {
     background-color: hsl(300, 50%, 50%);
     border-color: hsl(300, 50%, 30%);
+    fill: hsl(300, 50%, 50%);
+    stroke: hsl(300, 50%, 30%);
 }
 
 .block-dragging [ns="geolocation"],
 .block-dragging [ns="geolocation"].selected-block {
     background-color: hsl(300, 50%, 75%);
     border-color: hsl(300, 50%, 60%);
+    fill: hsl(300, 50%, 75%);
+    stroke: hsl(300, 50%, 60%);
 }
 
 [ns="size"],
 .block-dragging [ns="size"].drop-target,
-.block-dragging [ns="size"].drop-target.selected-block {
+.block-dragging [ns="size"].drop-target.selected-block{
     background-color: hsl(45, 50%, 50%);
     border-color: hsl(45, 50%, 30%);
+    fill: hsl(45, 50%, 50%);
+    stroke: hsl(45, 50%, 30%);
 }
 
 .block-dragging [ns="size"],
 .block-dragging [ns="size"].selected-block {
     background-color: hsl(45, 50%, 75%);
     border-color: hsl(45, 50%, 60%);
+    fill: hsl(45, 50%, 75%);
+    stroke: hsl(45, 50%, 60%);
 }
 
 [ns="date"],
 .block-dragging [ns="date"].drop-target,
-.block-dragging [ns="date"].drop-target.selected-block {
+.block-dragging [ns="date"].drop-target.selected-block{
     background-color: hsl(55, 76%, 70%);
     border-color: hsl(53, 60%, 53%);
+    fill: hsl(55, 76%, 70%);
+    stroke: hsl(53, 60%, 53%);
 }
 
 .block-dragging [ns="date"],
 .block-dragging [ns="date"].selected-block {
     background-color: hsl(55, 76%, 70%);
     border-color: hsl(53, 60%, 53%);
+    fill: hsl(55, 76%, 70%);
+    stroke: hsl(53, 60%, 53%);
 }
 
 

--- a/images/tab.svg
+++ b/images/tab.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="40" height="12" id="tab">
-    <path fill="currentColor" stroke="black" id="tab-shape"
+    <path fill="white" stroke="grey" id="tab-shape"
         d="M 0 12 
         a 6 6 90 0 0 6 -6 
         a 6 6 90 0 1 6 -6

--- a/images/tab.svg
+++ b/images/tab.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="12" id="tab">
+    <path fill="currentColor" stroke="black" id="tab-shape"
+        d="M 0 12 
+        a 6 6 90 0 0 6 -6 
+        a 6 6 90 0 1 6 -6
+        h 16
+        a 6 6 90 0 1 6 6
+        a 6 6 90 0 0 6 6" />
+</svg>

--- a/js/block.js
+++ b/js/block.js
@@ -139,8 +139,8 @@
     }
 
     function setDefaultSlot(element){
-        let tab = dom.child(element, 'svg.slot');
-        if (!tab){
+        let slot = dom.child(element, 'svg.slot');
+        if (!slot){
             element.append(dom.svg('svg', {'class': 'slot', width: 40, height: 12}, [dom.svg('path', {d: tabPath})]));
         }
     }
@@ -1038,10 +1038,6 @@
 
 
     var ContainsProto = Object.create(HTMLElement.prototype);
-
-    ContainsProto.createdCallback = function containsCreated(){
-        setDefaultSlot(this);
-    };
 
     /* You sure love Object.defineProperty, dontcha, Eddie? */
     Object.defineProperty(ContainsProto, 'firstInstruction', {

--- a/js/block.js
+++ b/js/block.js
@@ -113,6 +113,38 @@
         return test;
     }
 
+    const tabMarkup = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="40" height="12">
+    <path
+        d="M 0 12 
+        a 6 6 90 0 0 6 -6 
+        a 6 6 90 0 1 6 -6
+        h 16
+        a 6 6 90 0 1 6 6
+        a 6 6 90 0 0 6 6" />
+    </svg>
+    `;
+    const tabPath=`M 0 12 
+    a 6 6 90 0 0 6 -6 
+    a 6 6 90 0 1 6 -6
+    h 16
+    a 6 6 90 0 1 6 6
+    a 6 6 90 0 0 6 6`
+
+    function setDefaultTab(element){
+        let tab = dom.child(element, 'svg.tab');
+        if (!tab){
+            element.prepend(dom.svg('svg', {'class': 'tab', width: 40, height: 12}, [dom.svg('path', {d: tabPath})]));
+        }
+    }
+
+    function setDefaultSlot(element){
+        let tab = dom.child(element, 'svg.slot');
+        if (!tab){
+            element.append(dom.svg('svg', {'class': 'slot', width: 40, height: 12}, [dom.svg('path', {d: tabPath})]));
+        }
+    }
+
     /*****************
      *
      *  BlockProto
@@ -356,6 +388,13 @@
 
     var StepProto = Object.create(BlockProto);
 
+    StepProto.createdCallback = function stepCreated() {
+        BlockProto.createdCallback.call(this);
+        setDefaultTab(this);
+        setDefaultSlot(this);
+    };
+
+
     StepProto.getLocals = function stepGetLocals() {
         // For Steps this should work, but for contexts we need to gather the steps and contexts
         return dom.findAll(dom.child(this, 'header'), 'wb-local > *');
@@ -385,8 +424,10 @@
         // Add disclosure, contained, local
         BlockProto.createdCallback.call(this);
         var header = dom.child(this, 'header');
+        setDefaultTab(this);
         setDefaultByTag(header, 'wb-disclosure');
         setDefaultByTag(this, 'wb-contains');
+        setDefaultSlot(this);
     };
 
     ContextProto.childContainers = function childContainers() {
@@ -997,6 +1038,11 @@
 
 
     var ContainsProto = Object.create(HTMLElement.prototype);
+
+    ContainsProto.createdCallback = function containsCreated(){
+        setDefaultSlot(this);
+    };
+
     /* You sure love Object.defineProperty, dontcha, Eddie? */
     Object.defineProperty(ContainsProto, 'firstInstruction', {
         get: function() {


### PR DESCRIPTION
Puts tabs and slots back into blocks to make the connections more visual (and more Scratch-like). By popular request.

Fixes #937.